### PR TITLE
Three ways a traced mjlab task's fidelity slipped: history order, subclassed configs, entity writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,24 +137,50 @@ All kept as aliases via `_compat.py`, removed in 0.9:
   into the serializer, which failed on the first mjswan-only field it read
   (`AttributeError: 'ObservationTermCfg' object has no attribute 'history_steps'`). The
   whole MRO is consulted now, not the leaf class.
-- A traced mjlab task's observation history stacks in mjlab's order. mjlab flattens a
-  term's `CircularBuffer` chronologically — `[x_{t-3} … x_t]`, oldest frame first — while
-  a bare `history_length` counts back from the newest, so every mjlab task carrying
-  per-term or group history handed its policy a correct-width observation with time
-  running backwards. The adapter now resolves an mjlab count into the explicit
-  `history_steps` that reproduce its order (`(n-1, …, 0)`), so mjswan's own
-  `history_length` keeps its newest-first meaning for hand-written configs. Neither the
-  parity harness nor a build error could have caught this: parity compares term bodies,
-  and history is orchestration around them.
-- An event's write now lands on the entity it was made on. The write target's entity was
-  read off an `asset_cfg` param, which mjlab's own terms carry but a task's term need not
-  — a thrown ball's launcher takes a plain `ball_name` — so it serialized as `null`, and
-  the runtime then wrote every root pose to the model's *first* free joint. In a
-  two-entity scene (a robot and a ball) that launched the robot across the floor while
-  the ball never moved. The tracer records the entity from the write itself, `asset_cfg`
-  stays the fallback, and the runtime resolves a named entity's own free joint through
-  its body prefix. Two entities writing the same kind in one term is now an error rather
-  than a silent drop.
+- **`history_length` now stacks oldest frame first** — `[x_{t-n+1} … x_t]`, the order
+  mjlab's `CircularBuffer` flattens — where it counted back from the newest frame. Every
+  mjlab task carrying per-term or group history was handing its policy a correct-*width*
+  observation with time running backwards, and the two sides now mean one thing by a
+  count. **A hand-written config trained on the newest-first layout must name its offsets
+  to keep it:** `history_length=3` becomes `history_steps=(0, 1, 2)`. The bundled examples
+  are migrated; `history_steps` is unchanged and still takes precedence. Neither the
+  parity harness nor a build error could have caught the mismatch: parity compares term
+  bodies, and history is orchestration around them.
+- `PolicyRunner`'s group-level frame stack (the hand-authored `{components,
+  history_steps}` config shape) stacks oldest-first too, so one rule holds across both
+  history paths. `history_interleaved` follows the stack, so its layout is now
+  `[a0_{t-n+1}, …, a0_t, a1_…]`.
+- A group's `history_length` replaces its terms' whenever it is set — `0` included, which
+  switches history off for the group, as mjlab's `ObservationManager` does. An explicit
+  `0` used to read as "unset" and leave each term's own count standing.
+- An event's write now lands on the entity it was made on, and on each entity it was made
+  on. The write target's entity was read off an `asset_cfg` param, which mjlab's own terms
+  carry but a task's term need not — a thrown ball's launcher takes a plain `ball_name` —
+  so it serialized as `null`, and the runtime then wrote every root pose to the model's
+  *first* free joint. In a two-entity scene (a robot and a ball) that launched the robot
+  across the floor while the ball never moved. The tracer keys a capture by `(entity,
+  kind)`, as mjlab writes per entity, so one term may now write several; each target
+  names the graph outputs holding its values. `asset_cfg` stays the fallback for a write
+  the proxies could not attribute, and its `joint_ids` scope its own entity only.
+- The runtime resolves a named entity's free joint through its **joint** name prefix, the
+  same rule mjlab uses to resolve an entity's own addresses (and the one `entityJointIds`
+  already applied). A namespaced model with no such entity now writes nothing rather than
+  falling back to the first free joint — mjlab raises on the scene lookup, and the
+  fallback is how a thrown ball launches the robot. An unprefixed model is still a
+  single-entity scene, where the one free joint is the entity's.
+- A root velocity write rotates its angular half into the body frame, as mjlab's
+  `write_root_velocity` does. Both halves arrive world-frame, but a free joint's `qvel`
+  holds world-frame linear and *body*-frame angular velocity, so the value was spinning
+  the body about the wrong axis for any orientation but identity.
+- `write_root_state_to_sim` traces, split into the pose and velocity writes mjlab splits
+  it into, and a `write_*_to_sim` the tracer does *not* capture is refused instead of
+  forwarded — forwarding it mutated the live tracing env, leaving every term traced after
+  it reading a moved sim. A term walking `scene.entities` gets recording stand-ins for the
+  same reason.
+- mjlab's default `reset_scene_to_default` event no longer fails the build. It restores
+  every entity's default root and joint state, which is what the runtime's own reset
+  already does (`mj_resetData` to `qpos0`, or keyframe 0) before any `mode="reset"` event
+  runs, so it is emitted as a native no-op with that reason.
 - `run_parity` no longer feeds a graph inputs it does not declare, matching the runtime.
   A read the body only *indexes* with — a tracking command's `time_steps` — is recorded
   as a slot but folded in as a constant, so the export prunes it and ORT refused the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,22 @@ All kept as aliases via `_compat.py`, removed in 0.9:
   place — on the very object the task's live env config holds, leaving mjlab unable to
   resolve them when the tracing env was built, several frames from the cause. An
   unrecognized term is now copied rather than shared.
+- The observation and termination adapters convert a config wherever its class lives,
+  as the command and action adapters now do. `_is_from_mjlab` read the class's own
+  module, so a task's *subclass* of an mjlab `ObservationGroupCfg` — how a project adds
+  a field mjlab has no notion of — passed through unadapted, carrying mjlab term objects
+  into the serializer, which failed on the first mjswan-only field it read
+  (`AttributeError: 'ObservationTermCfg' object has no attribute 'history_steps'`). The
+  whole MRO is consulted now, not the leaf class.
+- A traced mjlab task's observation history stacks in mjlab's order. mjlab flattens a
+  term's `CircularBuffer` chronologically — `[x_{t-3} … x_t]`, oldest frame first — while
+  a bare `history_length` counts back from the newest, so every mjlab task carrying
+  per-term or group history handed its policy a correct-width observation with time
+  running backwards. The adapter now resolves an mjlab count into the explicit
+  `history_steps` that reproduce its order (`(n-1, …, 0)`), so mjswan's own
+  `history_length` keeps its newest-first meaning for hand-written configs. Neither the
+  parity harness nor a build error could have caught this: parity compares term bodies,
+  and history is orchestration around them.
 - `run_parity` no longer feeds a graph inputs it does not declare, matching the runtime.
   A read the body only *indexes* with — a tracking command's `time_steps` — is recorded
   as a slot but folded in as a constant, so the export prunes it and ORT refused the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,15 @@ All kept as aliases via `_compat.py`, removed in 0.9:
   `history_length` keeps its newest-first meaning for hand-written configs. Neither the
   parity harness nor a build error could have caught this: parity compares term bodies,
   and history is orchestration around them.
+- An event's write now lands on the entity it was made on. The write target's entity was
+  read off an `asset_cfg` param, which mjlab's own terms carry but a task's term need not
+  — a thrown ball's launcher takes a plain `ball_name` — so it serialized as `null`, and
+  the runtime then wrote every root pose to the model's *first* free joint. In a
+  two-entity scene (a robot and a ball) that launched the robot across the floor while
+  the ball never moved. The tracer records the entity from the write itself, `asset_cfg`
+  stays the fallback, and the runtime resolves a named entity's own free joint through
+  its body prefix. Two entities writing the same kind in one term is now an error rather
+  than a silent drop.
 - `run_parity` no longer feeds a graph inputs it does not declare, matching the runtime.
   A read the body only *indexes* with — a tracking command's `time_steps` — is recorded
   as a slot but folded in as a constant, so the export prunes it and ORT refused the

--- a/examples/demo/gentle_humanoid/main.py
+++ b/examples/demo/gentle_humanoid/main.py
@@ -342,10 +342,11 @@ def setup_builder() -> mjswan.Builder:
                     params={"asset_cfg": policy_joints},
                     history_steps=tuple(tracking_cfg["joint_vel_history_steps"]),
                 ),
-                # The runtime already holds `last_action`, so only the stacking is ours.
+                # The runtime already holds `last_action`, so only the stacking is ours
+                # — newest first, like the offsets the checkpoint names above.
                 "prev_actions": ObservationTermCfg(
                     func=obs_fns.last_action,
-                    history_length=int(tracking_cfg["prev_action_steps"]),
+                    history_steps=tuple(range(int(tracking_cfg["prev_action_steps"]))),
                 ),
             }
         ),

--- a/examples/demo/main.py
+++ b/examples/demo/main.py
@@ -46,6 +46,10 @@ from mjswan.trace_env import build_single_entity_trace_env  # noqa: E402
 # own trace env via SceneHandle.set_trace_env, and the terms below are written against
 # the same live-env API mjlab's own use. ---
 
+#: Three frames, newest first. `history_length` stacks chronologically (mjlab's order);
+#: these Go2 checkpoints were trained on the reverse, so they name the offsets.
+GO2_HISTORY_STEPS = (0, 1, 2)
+
 
 def joint_pos_abs(env, *, asset_cfg: SceneEntityCfg = SceneEntityCfg(name="robot")):
     """Absolute joint positions (no default-pose subtraction)."""
@@ -242,17 +246,17 @@ def _add_go2_scene(project) -> None:
         "policy": ObservationGroupCfg(
             terms={
                 "projected_gravity": ObservationTermCfg(
-                    func=obs_fns.projected_gravity, history_length=3
+                    func=obs_fns.projected_gravity, history_steps=GO2_HISTORY_STEPS
                 ),
                 "joint_pos": ObservationTermCfg(
-                    func=obs_fns.joint_pos_rel, history_length=3
+                    func=obs_fns.joint_pos_rel, history_steps=GO2_HISTORY_STEPS
                 ),
                 "joint_vel": ObservationTermCfg(
-                    func=obs_fns.joint_vel_rel, history_length=3
+                    func=obs_fns.joint_vel_rel, history_steps=GO2_HISTORY_STEPS
                 ),
                 "prev_actions": ObservationTermCfg(
                     func=obs_fns.last_action,
-                    history_length=3,
+                    history_steps=GO2_HISTORY_STEPS,
                     history_interleaved=True,
                 ),
             }
@@ -279,17 +283,17 @@ def _add_go2_scene(project) -> None:
             "policy": ObservationGroupCfg(
                 terms={
                     "projected_gravity": ObservationTermCfg(
-                        func=obs_fns.projected_gravity, history_length=3
+                        func=obs_fns.projected_gravity, history_steps=GO2_HISTORY_STEPS
                     ),
                     "joint_pos": ObservationTermCfg(
-                        func=joint_pos_abs, history_length=3
+                        func=joint_pos_abs, history_steps=GO2_HISTORY_STEPS
                     ),
                     "joint_vel": ObservationTermCfg(
-                        func=obs_fns.joint_vel_rel, history_length=3
+                        func=obs_fns.joint_vel_rel, history_steps=GO2_HISTORY_STEPS
                     ),
                     "prev_actions": ObservationTermCfg(
                         func=obs_fns.last_action,
-                        history_length=3,
+                        history_steps=GO2_HISTORY_STEPS,
                         history_interleaved=True,
                     ),
                 }

--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -131,9 +131,11 @@ def _apply_observation_pipeline(
         )
     if term_cfg.clip is not None:
         entry["clip"] = list(term_cfg.clip)
+    # A group count replaces the term's whenever it is set, `0` included, as mjlab's
+    # own `ObservationManager` does.
     history = (
         group_history_length
-        if (group_history_length or 0) > 0
+        if group_history_length is not None
         else term_cfg.history_length
     )
     if term_cfg.history_steps:
@@ -213,7 +215,9 @@ def _effective_history(group: ObservationGroupCfg, term_cfg: ObservationTermCfg)
     """
     if term_cfg.history_steps:
         return len(term_cfg.history_steps)
-    return int(group.history_length or term_cfg.history_length or 0)
+    if group.history_length is not None:
+        return int(group.history_length)
+    return int(term_cfg.history_length or 0)
 
 
 def _group_is_fusable(group: ObservationGroupCfg) -> bool:
@@ -784,6 +788,11 @@ _EVENTS_WITH_NOTHING_TO_WRITE: dict[str, str] = {
     "encoder_bias": (
         "it writes `Entity.data.encoder_bias`, which the runtime applies from the policy "
         "config's `encoder_bias` rather than from an event graph"
+    ),
+    "reset_scene_to_default": (
+        "it restores every entity's default root and joint state, which is what the "
+        "runtime's own reset already does (`mj_resetData` to `qpos0`, or keyframe 0) "
+        'before any `mode="reset"` event runs'
     ),
 }
 

--- a/src/mjswan/adapters/mjlab_adapter.py
+++ b/src/mjswan/adapters/mjlab_adapter.py
@@ -58,9 +58,17 @@ from ..managers.termination_manager import (
 
 
 def _is_from_mjlab(obj: Any) -> bool:
-    """Check whether *obj*'s class originates from the ``mjlab`` package."""
-    module = getattr(type(obj), "__module__", "") or ""
-    return module.startswith("mjlab")
+    """Check whether *obj*'s class derives from the ``mjlab`` package.
+
+    The whole MRO, not just the class: a task is free to subclass an mjlab config to
+    add a field of its own, and such a subclass reports its *own* module. Missing it
+    would pass the config through unadapted — mjlab term objects reaching the
+    serializer, where they fail on the first mjswan-only field.
+    """
+    return any(
+        (getattr(klass, "__module__", "") or "").startswith("mjlab")
+        for klass in type(obj).__mro__
+    )
 
 
 # --- Observation adaptation ---
@@ -122,8 +130,21 @@ def _sanitize_obs_params(params: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _mjlab_history_steps(frames: int) -> tuple[int, ...]:
+    """mjlab's dense stack, as the look-back offsets that reproduce its order.
+
+    mjlab flattens a term's ``CircularBuffer`` chronologically — ``[x_{t-n+1} … x_t]``,
+    oldest frame first — while a bare ``history_length`` counts outward from the newest
+    frame. Naming the offsets pins mjlab's order for a traced task without moving
+    mjswan's own default.
+    """
+    return tuple(range(frames - 1, -1, -1))
+
+
 def _adapt_obs_term(
-    term: Any, term_name: str | None = None
+    term: Any,
+    term_name: str | None = None,
+    group_history_length: int | None = None,
 ) -> MjswanObservationTermCfg:
     """Convert a single mjlab ``ObservationTermCfg`` to mjswan.
 
@@ -138,26 +159,34 @@ def _adapt_obs_term(
         if isinstance(func, ObservationBinding)
         else raw_params
     )
+    # The group level overrides the term's, as mjlab's own `ObservationManager` does.
+    frames = int(group_history_length or getattr(term, "history_length", 0) or 0)
     return MjswanObservationTermCfg(
         func=func,
         params=params,
         scale=getattr(term, "scale", None),
         clip=getattr(term, "clip", None),
-        history_length=getattr(term, "history_length", 0) or 0,
+        history_steps=_mjlab_history_steps(frames) if frames > 1 else None,
     )
 
 
 def _adapt_obs_group(group: Any) -> MjswanObservationGroupCfg:
-    """Convert a single mjlab ``ObservationGroupCfg`` to mjswan."""
+    """Convert a single mjlab ``ObservationGroupCfg`` to mjswan.
+
+    Any history the group declares is resolved into its terms' ``history_steps``, so the
+    adapted group carries no count of its own — mjlab stacks per term anyway, and the
+    offsets already say which frames and in which order.
+    """
     raw_terms = getattr(group, "terms", None) or {}
+    group_history = getattr(group, "history_length", None)
     terms = {
-        name: _adapt_obs_term(cfg, term_name=name) for name, cfg in raw_terms.items()
+        name: _adapt_obs_term(cfg, term_name=name, group_history_length=group_history)
+        for name, cfg in raw_terms.items()
     }
     return MjswanObservationGroupCfg(
         terms=terms,
         concatenate_terms=getattr(group, "concatenate_terms", True),
         enable_corruption=getattr(group, "enable_corruption", False),
-        history_length=getattr(group, "history_length", None),
     )
 
 

--- a/src/mjswan/adapters/mjlab_adapter.py
+++ b/src/mjswan/adapters/mjlab_adapter.py
@@ -4,9 +4,9 @@ mjlab is a **soft dependency** — this module never fails at import time.
 When mjlab is not installed the ``adapt_*`` functions simply return their
 inputs unchanged (they are assumed to already be mjswan types).
 
-The adapter detects mjlab types by checking the module path of the class
-(``type(obj).__module__``) rather than ``isinstance``, so mjlab does not
-need to be importable for mjswan to function.
+The adapter detects mjlab types by the module path of any class in the MRO
+rather than ``isinstance``, so mjlab does not need to be importable for
+mjswan to function.
 
 Mapping strategy
 ----------------
@@ -60,10 +60,8 @@ from ..managers.termination_manager import (
 def _is_from_mjlab(obj: Any) -> bool:
     """Check whether *obj*'s class derives from the ``mjlab`` package.
 
-    The whole MRO, not just the class: a task is free to subclass an mjlab config to
-    add a field of its own, and such a subclass reports its *own* module. Missing it
-    would pass the config through unadapted — mjlab term objects reaching the
-    serializer, where they fail on the first mjswan-only field.
+    The whole MRO, not just the leaf: a task subclassing an mjlab config to add a
+    field of its own reports its *own* module.
     """
     return any(
         (getattr(klass, "__module__", "") or "").startswith("mjlab")
@@ -130,21 +128,8 @@ def _sanitize_obs_params(params: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
-def _mjlab_history_steps(frames: int) -> tuple[int, ...]:
-    """mjlab's dense stack, as the look-back offsets that reproduce its order.
-
-    mjlab flattens a term's ``CircularBuffer`` chronologically — ``[x_{t-n+1} … x_t]``,
-    oldest frame first — while a bare ``history_length`` counts outward from the newest
-    frame. Naming the offsets pins mjlab's order for a traced task without moving
-    mjswan's own default.
-    """
-    return tuple(range(frames - 1, -1, -1))
-
-
 def _adapt_obs_term(
-    term: Any,
-    term_name: str | None = None,
-    group_history_length: int | None = None,
+    term: Any, term_name: str | None = None
 ) -> MjswanObservationTermCfg:
     """Convert a single mjlab ``ObservationTermCfg`` to mjswan.
 
@@ -159,34 +144,26 @@ def _adapt_obs_term(
         if isinstance(func, ObservationBinding)
         else raw_params
     )
-    # The group level overrides the term's, as mjlab's own `ObservationManager` does.
-    frames = int(group_history_length or getattr(term, "history_length", 0) or 0)
     return MjswanObservationTermCfg(
         func=func,
         params=params,
         scale=getattr(term, "scale", None),
         clip=getattr(term, "clip", None),
-        history_steps=_mjlab_history_steps(frames) if frames > 1 else None,
+        history_length=getattr(term, "history_length", 0) or 0,
     )
 
 
 def _adapt_obs_group(group: Any) -> MjswanObservationGroupCfg:
-    """Convert a single mjlab ``ObservationGroupCfg`` to mjswan.
-
-    Any history the group declares is resolved into its terms' ``history_steps``, so the
-    adapted group carries no count of its own — mjlab stacks per term anyway, and the
-    offsets already say which frames and in which order.
-    """
+    """Convert a single mjlab ``ObservationGroupCfg`` to mjswan."""
     raw_terms = getattr(group, "terms", None) or {}
-    group_history = getattr(group, "history_length", None)
     terms = {
-        name: _adapt_obs_term(cfg, term_name=name, group_history_length=group_history)
-        for name, cfg in raw_terms.items()
+        name: _adapt_obs_term(cfg, term_name=name) for name, cfg in raw_terms.items()
     }
     return MjswanObservationGroupCfg(
         terms=terms,
         concatenate_terms=getattr(group, "concatenate_terms", True),
         enable_corruption=getattr(group, "enable_corruption", False),
+        history_length=getattr(group, "history_length", None),
     )
 
 

--- a/src/mjswan/compile/parity.py
+++ b/src/mjswan/compile/parity.py
@@ -16,6 +16,7 @@ import torch
 from .rng import DrawRecorder
 from .tracer import (
     TermExport,
+    WriteCaptures,
     _EventCaptureEnv,
     _flatten_captures,
     read_slot,
@@ -247,7 +248,7 @@ def run_parity(
             )
             for _ in range(n_event_draws):
                 # Record a fresh reference invocation (real draws, no sim write).
-                captures: dict[str, tuple] = {}
+                captures: WriteCaptures = {}
                 proxy = _EventCaptureEnv(env, [], captures)
                 with DrawRecorder(func) as rec:
                     func(proxy, None, **params)

--- a/src/mjswan/compile/tracer.py
+++ b/src/mjswan/compile/tracer.py
@@ -725,35 +725,37 @@ _WRITE_FIELDS: dict[str, tuple[str, ...]] = {
 }
 
 
-class WriteCaptures(dict):
-    """``kind`` → written tensors, plus the entity each write was made on.
+#: A write is keyed by the entity it was made on as well as its kind: one term may
+#: write several entities — mjlab's own `reset_scene_to_default` writes every entity
+#: in the scene — and each needs its own outputs and its own target.
+WriteKey = tuple[str | None, str]
+WriteCaptures = dict[WriteKey, tuple[torch.Tensor, ...]]
 
-    A term names its target however it likes — mjlab's own convention is an
-    ``asset_cfg`` param, but a task is free to take a plain ``ball_name`` — so the
-    entity is recorded from the write itself rather than guessed from the params.
+
+def _write_output_name(key: WriteKey, field_name: str) -> str:
+    """Graph-output name for one written tensor.
+
+    Unprefixed when the write carries no entity, which is what a single-entity command
+    term records.
     """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.entities: dict[str, str] = {}
+    entity, kind = key
+    return f"{entity}__{kind}__{field_name}" if entity else f"{kind}__{field_name}"
 
 
 class _WriteCaptureMixin:
-    """Records ``write_*_to_sim`` calls into ``self._captures`` (kind → tensors)."""
+    """Records ``write_*_to_sim`` calls into ``self._captures``.
+
+    A term names its target however it likes — mjlab's own convention is an
+    ``asset_cfg`` param, but a task is free to take a plain ``ball_name`` — so the
+    entity comes from the write itself rather than from the params.
+    """
+
+    #: Entity this proxy stands for; None for a command term whose cfg names none.
+    _name: str | None
+    _captures: WriteCaptures
 
     def _capture(self, kind: str, values: tuple[Any, ...]) -> None:
-        self._captures[kind] = values
-        entities = getattr(self._captures, "entities", None)
-        name = getattr(self, "_name", None)
-        if entities is None or name is None:
-            return
-        previous = entities.get(kind)
-        if previous is not None and previous != name:
-            raise ValueError(
-                f"Term wrote {kind!r} on both {previous!r} and {name!r}; the browser "
-                "applies one write per kind, so it would land on one of them only."
-            )
-        entities[kind] = name
+        self._captures[(self._name, kind)] = values
 
     def write_joint_state_to_sim(
         self, position, velocity, joint_ids=None, env_ids=None
@@ -766,9 +768,14 @@ class _WriteCaptureMixin:
     def write_root_link_velocity_to_sim(self, velocity, env_ids=None):
         self._capture("root_velocity", (velocity,))
 
+    def write_root_state_to_sim(self, root_state, env_ids=None):
+        # mjlab's own split of a 13-wide root state into the two writes above.
+        self._capture("root_pose", (root_state[..., :7],))
+        self._capture("root_velocity", (root_state[..., 7:],))
+
 
 def _flatten_captures(
-    captures: dict[str, tuple[torch.Tensor, ...]],
+    captures: WriteCaptures,
 ) -> tuple[list[str], list[torch.Tensor]]:
     """Flatten a captures dict into (output_names, tensors).
 
@@ -777,9 +784,9 @@ def _flatten_captures(
     """
     names: list[str] = []
     tensors: list[torch.Tensor] = []
-    for kind, values in captures.items():
-        for field_name, tensor in zip(_WRITE_FIELDS[kind], values):
-            names.append(f"{kind}__{field_name}")
+    for key, values in captures.items():
+        for field_name, tensor in zip(_WRITE_FIELDS[key[1]], values):
+            names.append(_write_output_name(key, field_name))
             tensors.append(tensor)
     return names, tensors
 
@@ -809,6 +816,13 @@ class _EvRecEntity(_WriteCaptureMixin):
         object.__setattr__(self, "_captures", captures)
 
     def __getattr__(self, name: str) -> Any:
+        if name.startswith("write_") and name.endswith("_to_sim"):
+            # Forwarding it would mutate the live env mid-trace and capture nothing.
+            raise ValueError(
+                f"Term called {name}() on entity {self._name!r}, which the tracer does "
+                "not capture. Add it to `_WriteCaptureMixin` and `_WRITE_FIELDS` with a "
+                "runtime counterpart, or hand the term to the browser as a TS class."
+            )
         value = getattr(self._real, name)
         # Only tensors and control-flow scalars can be reproduced during replay.
         if isinstance(value, (torch.Tensor, bool, int, float)):
@@ -836,6 +850,14 @@ class _EvRecScene:
         return _EvRecEntity(self._real[name], name, self._log, self._captures)
 
     def __getattr__(self, name: str) -> Any:
+        if name == "entities":
+            # Recording stand-ins, not the live entities: a term that iterates the
+            # scene (mjlab's `reset_scene_to_default`) would otherwise write straight
+            # into the tracing env, leaving every later term traced against a moved sim.
+            return {
+                key: _EvRecEntity(real, key, self._log, self._captures)
+                for key, real in self._real.entities.items()
+            }
         value = getattr(self._real, name)
         if isinstance(value, (torch.Tensor, bool, int, float)):
             self._log.append((("scene", name), value))
@@ -885,14 +907,22 @@ class _EvReplayEntity(_WriteCaptureMixin):
 
 
 class _EvReplayScene:
-    def __init__(self, served, captures):
+    def __init__(self, served, captures, real_env: Any):
         self._served = served
         self._captures = captures
+        self._real_env = real_env
 
     def __getitem__(self, name: str) -> _EvReplayEntity:
         return _EvReplayEntity(name, self._served, self._captures)
 
     def __getattr__(self, name: str) -> Any:
+        if name == "entities":
+            # Which entities the scene holds is static structure, so it comes from the
+            # real env, as `num_envs` does — only their tensors are recorded slots.
+            return {
+                key: _EvReplayEntity(key, self._served, self._captures)
+                for key in self._real_env.scene.entities
+            }
         try:
             return self._served[("scene", name)]
         except KeyError:
@@ -903,7 +933,7 @@ class _EvReplayScene:
 
 class _EventReplayEnv:
     def __init__(self, served, captures, *, real_env: Any):
-        self.scene = _EvReplayScene(served, captures)
+        self.scene = _EvReplayScene(served, captures, real_env)
         self._real_env = real_env
 
     def __getattr__(self, name: str) -> Any:
@@ -945,7 +975,7 @@ class _EventModule(nn.Module):
         served.update(_const_values(self, self._const_buffers))
         for (entity, field_name), tensor in zip(self._dynamic_keys, dynamic):
             served[("data", entity, field_name)] = tensor
-        captures = WriteCaptures()
+        captures: WriteCaptures = {}
         env = _EventReplayEnv(served, captures, real_env=self._real_env)
         with ReplayRng(self._func, rand):
             self._func(env, None, **self._params)
@@ -1024,16 +1054,16 @@ def trace_event_term(
     """
     # 1. Discovery on the live env: record draws + reads + written values.
     log: list[tuple[TaggedKey, Any]] = []
-    captures = WriteCaptures()
+    captures: WriteCaptures = {}
     proxy = _EventCaptureEnv(env, log, captures)
     with DrawRecorder(func) as rec:
         func(proxy, None, **params)
 
     if not captures:
         raise ValueError(
-            f"Event term {name!r} wrote nothing traceable "
-            "(no write_joint_state/root_pose/root_velocity_to_sim call); handle "
-            "it natively or extend _WRITE_FIELDS."
+            f"Event term {name!r} wrote nothing traceable (no write_joint_state / "
+            "write_root_state / write_root_link_pose / write_root_link_velocity call); "
+            "handle it natively or extend _WRITE_FIELDS."
         )
     output_names, ref_tensors = _flatten_captures(captures)
     ref_rand = rec.rand_vector
@@ -1066,20 +1096,22 @@ def trace_event_term(
     # The write itself says which entity it landed on; `asset_cfg` is the fallback for a
     # term whose write the proxies did not attribute.
     asset_cfg = params.get("asset_cfg")
-    fallback_entity = getattr(asset_cfg, "name", None)
-    write_targets = [
-        {
+    asset_name = getattr(asset_cfg, "name", None)
+    write_targets = []
+    for key in captures:
+        entity, kind = key
+        target: dict[str, Any] = {
             "kind": kind,
-            "entity": captures.entities.get(kind, fallback_entity),
+            "entity": entity or asset_name,
             "fields": list(_WRITE_FIELDS[kind]),
-            **(
-                {"joint_ids": _static_ids(getattr(asset_cfg, "joint_ids", None))}
-                if kind == "joint_state"
-                else {}
-            ),
+            "outputs": [_write_output_name(key, f) for f in _WRITE_FIELDS[kind]],
         }
-        for kind in captures
-    ]
+        # `asset_cfg`'s ids scope its own entity; any other one gets all of its joints.
+        joint_ids = _static_ids(getattr(asset_cfg, "joint_ids", None))
+        scoped = entity is None or entity == asset_name
+        if kind == "joint_state" and scoped and joint_ids is not None:
+            target["joint_ids"] = joint_ids
+        write_targets.append(target)
 
     return EventExport(
         name=name,
@@ -1142,7 +1174,7 @@ class _RecordCommand:
         self._attrs = entity_attr_names
         self._entity_name = entity_name
         self.log: list[tuple[TaggedKey, Any]] = []
-        self.captures: dict[str, tuple[torch.Tensor, ...]] = {}
+        self.captures: WriteCaptures = {}
 
     def __enter__(self) -> _RecordCommand:
         self._orig = {a: getattr(self.term, a) for a in self._attrs}
@@ -1234,7 +1266,7 @@ class _CommandModule(nn.Module):
         for (entity, field_name), tensor in zip(self._dynamic_keys, dynamic):
             served[("data", entity, field_name)] = tensor
 
-        captures: dict[str, tuple[torch.Tensor, ...]] = {}
+        captures: WriteCaptures = {}
         orig = {a: getattr(self._term, a) for a in self._entity_attr_names}
         orig_env = getattr(self._term, "_env", None)
         for a in self._entity_attr_names:
@@ -1325,8 +1357,15 @@ def trace_command_term(
 
     output_write_names, _ = _flatten_captures(captures)
     write_targets = [
-        {"kind": kind, "entity": entity_name, "fields": list(_WRITE_FIELDS[kind])}
-        for kind in captures
+        {
+            "kind": kind,
+            "entity": entity or entity_name,
+            "fields": list(_WRITE_FIELDS[kind]),
+            "outputs": [
+                _write_output_name((entity, kind), f) for f in _WRITE_FIELDS[kind]
+            ],
+        }
+        for entity, kind in captures
     ]
 
     # 2. Classify reads: dynamic data inputs vs baked tensor/scalar constants.

--- a/src/mjswan/compile/tracer.py
+++ b/src/mjswan/compile/tracer.py
@@ -725,19 +725,46 @@ _WRITE_FIELDS: dict[str, tuple[str, ...]] = {
 }
 
 
+class WriteCaptures(dict):
+    """``kind`` → written tensors, plus the entity each write was made on.
+
+    A term names its target however it likes — mjlab's own convention is an
+    ``asset_cfg`` param, but a task is free to take a plain ``ball_name`` — so the
+    entity is recorded from the write itself rather than guessed from the params.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.entities: dict[str, str] = {}
+
+
 class _WriteCaptureMixin:
     """Records ``write_*_to_sim`` calls into ``self._captures`` (kind → tensors)."""
+
+    def _capture(self, kind: str, values: tuple[Any, ...]) -> None:
+        self._captures[kind] = values
+        entities = getattr(self._captures, "entities", None)
+        name = getattr(self, "_name", None)
+        if entities is None or name is None:
+            return
+        previous = entities.get(kind)
+        if previous is not None and previous != name:
+            raise ValueError(
+                f"Term wrote {kind!r} on both {previous!r} and {name!r}; the browser "
+                "applies one write per kind, so it would land on one of them only."
+            )
+        entities[kind] = name
 
     def write_joint_state_to_sim(
         self, position, velocity, joint_ids=None, env_ids=None
     ):
-        self._captures["joint_state"] = (position, velocity)
+        self._capture("joint_state", (position, velocity))
 
     def write_root_link_pose_to_sim(self, pose, env_ids=None):
-        self._captures["root_pose"] = (pose,)
+        self._capture("root_pose", (pose,))
 
     def write_root_link_velocity_to_sim(self, velocity, env_ids=None):
-        self._captures["root_velocity"] = (velocity,)
+        self._capture("root_velocity", (velocity,))
 
 
 def _flatten_captures(
@@ -918,7 +945,7 @@ class _EventModule(nn.Module):
         served.update(_const_values(self, self._const_buffers))
         for (entity, field_name), tensor in zip(self._dynamic_keys, dynamic):
             served[("data", entity, field_name)] = tensor
-        captures: dict[str, tuple[torch.Tensor, ...]] = {}
+        captures = WriteCaptures()
         env = _EventReplayEnv(served, captures, real_env=self._real_env)
         with ReplayRng(self._func, rand):
             self._func(env, None, **self._params)
@@ -997,7 +1024,7 @@ def trace_event_term(
     """
     # 1. Discovery on the live env: record draws + reads + written values.
     log: list[tuple[TaggedKey, Any]] = []
-    captures: dict[str, tuple[torch.Tensor, ...]] = {}
+    captures = WriteCaptures()
     proxy = _EventCaptureEnv(env, log, captures)
     with DrawRecorder(func) as rec:
         func(proxy, None, **params)
@@ -1036,12 +1063,14 @@ def trace_event_term(
         opset=opset,
     )
 
+    # The write itself says which entity it landed on; `asset_cfg` is the fallback for a
+    # term whose write the proxies did not attribute.
     asset_cfg = params.get("asset_cfg")
-    entity = getattr(asset_cfg, "name", None)
+    fallback_entity = getattr(asset_cfg, "name", None)
     write_targets = [
         {
             "kind": kind,
-            "entity": entity,
+            "entity": captures.entities.get(kind, fallback_entity),
             "fields": list(_WRITE_FIELDS[kind]),
             **(
                 {"joint_ids": _static_ids(getattr(asset_cfg, "joint_ids", None))}

--- a/src/mjswan/managers/observation_manager.py
+++ b/src/mjswan/managers/observation_manager.py
@@ -70,16 +70,22 @@ class ObservationTermCfg:
     """(min, max) clipping range applied after scaling."""
 
     history_length: int = 0
-    """Number of past frames to stack. 0 = current only (no history)."""
+    """Number of past frames to stack, newest first (``[x_t, x_{t-1}, …]``).
+    0 = current only (no history).
+
+    mjlab stacks the same frames in the opposite order — its buffer flattens
+    chronologically — so a traced mjlab task arrives with ``history_steps`` spelling
+    that order out, and never with a bare count."""
 
     history_steps: tuple[int, ...] | None = None
-    """Sparse look-back offsets to stack, instead of every frame.
+    """Look-back offsets to stack, in the order the policy reads them, instead of a
+    count of frames.
 
-    mjlab only counts frames (``history_length=n`` → offsets ``0..n-1``), but a
-    policy can be trained on a *sparse* window — e.g. ``(0, 1, 2, 4, 8, 16)``, which
-    reaches 17 frames back while contributing only 6. Naming the offsets keeps the
-    term's width at ``len(history_steps)`` frames; ``history_length`` would give 17.
-    Takes precedence over ``history_length`` when both are set."""
+    Two things a count cannot say. A *sparse* window — e.g. ``(0, 1, 2, 4, 8, 16)`` —
+    reaches 17 frames back while contributing only 6, keeping the term's width at
+    ``len(history_steps)`` where ``history_length`` would give 17. And an *order*:
+    ``(3, 2, 1, 0)`` is mjlab's oldest-first stack of four frames, the reverse of
+    ``history_length=4``. Takes precedence over ``history_length`` when both are set."""
 
     history_interleaved: bool = False
     """Isaac-style joint-major history layout: ``[a0_t, a0_t-1, ..., a1_t, ...]``

--- a/src/mjswan/managers/observation_manager.py
+++ b/src/mjswan/managers/observation_manager.py
@@ -70,27 +70,23 @@ class ObservationTermCfg:
     """(min, max) clipping range applied after scaling."""
 
     history_length: int = 0
-    """Number of past frames to stack, newest first (``[x_t, x_{t-1}, …]``).
-    0 = current only (no history).
-
-    mjlab stacks the same frames in the opposite order — its buffer flattens
-    chronologically — so a traced mjlab task arrives with ``history_steps`` spelling
-    that order out, and never with a bare count."""
+    """Number of past frames to stack, oldest first — ``[x_{t-n+1} … x_t]``, as
+    mjlab's chronological history buffer flattens them. 0 = current only."""
 
     history_steps: tuple[int, ...] | None = None
     """Look-back offsets to stack, in the order the policy reads them, instead of a
     count of frames.
 
-    Two things a count cannot say. A *sparse* window — e.g. ``(0, 1, 2, 4, 8, 16)`` —
+    Two things a count cannot say. A *sparse* window — e.g. ``(16, 8, 4, 2, 1, 0)`` —
     reaches 17 frames back while contributing only 6, keeping the term's width at
-    ``len(history_steps)`` where ``history_length`` would give 17. And an *order*:
-    ``(3, 2, 1, 0)`` is mjlab's oldest-first stack of four frames, the reverse of
+    ``len(history_steps)`` where ``history_length`` would give 17. And a different
+    *order*: ``(0, 1, 2, 3)`` stacks four frames newest-first, the reverse of
     ``history_length=4``. Takes precedence over ``history_length`` when both are set."""
 
     history_interleaved: bool = False
-    """Isaac-style joint-major history layout: ``[a0_t, a0_t-1, ..., a1_t, ...]``
-    instead of frame-major (``[a_t, a_t-1, ...]`` each the full vector). Only
-    meaningful when ``history_length`` > 0."""
+    """Isaac-style element-major history layout: ``[a0_{t-n+1}, …, a0_t, a1_…]``
+    instead of frame-major (``[x_{t-n+1}, …, x_t]``, each the full vector). Only
+    meaningful when history is stacked at all."""
 
     flatten_history_dim: bool = True
     """Whether to flatten history into the feature dimension.
@@ -159,7 +155,8 @@ class ObservationGroupCfg:
     """Accepted for mjlab compatibility; ignored (no training in browser)."""
 
     history_length: int | None = None
-    """Group-level history override. If set, applies to all terms."""
+    """Group-level history override. If not None, replaces every term's own count —
+    ``0`` included, which switches history off for the group, as in mjlab."""
 
     flatten_history_dim: bool = True
     """Accepted for mjlab compatibility; mjswan always flattens."""

--- a/src/mjswan/template/src/core/event/__tests__/entityWrite.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/entityWrite.test.ts
@@ -2,9 +2,11 @@
  * `entity_write` apply primitive (ADR 0005 §3).
  *
  * Take a value an ONNX graph already computed and write it into mjData — the
- * graph owns the sampling, so this side only applies. The write kinds and the
- * `"<kind>__<field>"` output naming mirror the Python tracer's `_WRITE_FIELDS`, so
- * these tests double as the contract between the two sides.
+ * graph owns the sampling, so this side only applies. The write kinds, the output
+ * naming (`"<entity>__<kind>__<field>"`, or `"<kind>__<field>"` from a bundle built
+ * before a term could write two entities) and the world-frame velocity convention
+ * mirror the Python tracer's `_WRITE_FIELDS`, so these tests double as the contract
+ * between the two sides.
  */
 import { describe, expect, it } from 'vitest';
 
@@ -53,11 +55,17 @@ function fakeModel(nHinge: number, withFreeJoint = true): MjModel {
 }
 
 /**
- * A robot (free joint + `nHinge` hinges) followed by a free-floating ball, named as
- * mjlab prefixes them: `robot/pelvis`, `ball/ball`.
+ * A robot (free joint + `nHinge` hinges) followed by a free-floating ball, with joints
+ * named as mjlab namespaces them — `robot/…`, `ball/…` — which is how it resolves an
+ * entity's own addresses.
  */
 function fakeSceneModel(nHinge = 2): MjModel {
   const jntType = [0, ...Array.from({ length: nHinge }, () => 3), 0];
+  const jntNames = [
+    'robot/floating_base_joint',
+    ...Array.from({ length: nHinge }, (_, i) => `robot/joint${i}`),
+    'ball/floating_base_joint',
+  ];
   const qposadr: number[] = [];
   const dofadr: number[] = [];
   let q = 0;
@@ -68,25 +76,20 @@ function fakeSceneModel(nHinge = 2): MjModel {
     q += type === 0 ? 7 : 1;
     d += type === 0 ? 6 : 1;
   }
-  // One body per joint, plus the world body at index 0.
-  const bodyNames = ['world', 'robot/pelvis', ...Array.from({ length: nHinge }, (_, i) => `robot/link${i}`), 'ball/ball'];
   const encoder = new TextEncoder();
   const blob: number[] = [];
-  const bodyAdr: number[] = [];
-  for (const name of bodyNames) {
-    bodyAdr.push(blob.length);
+  const jntAdr: number[] = [];
+  for (const name of jntNames) {
+    jntAdr.push(blob.length);
     blob.push(...encoder.encode(name), 0);
   }
   return {
     njnt: jntType.length,
-    nbody: bodyNames.length,
     jnt_type: Int32Array.from(jntType),
     jnt_qposadr: Int32Array.from(qposadr),
     jnt_dofadr: Int32Array.from(dofadr),
-    jnt_bodyid: Int32Array.from(jntType.map((_, j) => j + 1)),
     names: Uint8Array.from(blob).buffer,
-    name_jntadr: Int32Array.from(jntType.map(() => 0)),
-    name_bodyadr: Int32Array.from(bodyAdr),
+    name_jntadr: Int32Array.from(jntAdr),
     _nq: q,
     _nv: d,
   } as unknown as MjModel;
@@ -203,6 +206,7 @@ describe('applyEntityWrite: root pose / velocity', () => {
   it('writes the 6-vector velocity into the free joint qvel', () => {
     const model = fakeModel(1);
     const data = fakeData(model);
+    data.qpos.set([0, 0, 0, 1, 0, 0, 0], 0); // identity orientation
     const vel = new Float32Array([0.1, 0.2, 0.3, -0.1, -0.2, -0.3]);
     expect(
       applyEntityWrite(model, data, { kind: 'root_velocity', fields: ['velocity'] }, {
@@ -210,6 +214,45 @@ describe('applyEntityWrite: root pose / velocity', () => {
       }),
     ).toBe(true);
     for (let i = 0; i < 6; i++) expect(data.qvel[i]).toBeCloseTo(vel[i], 6);
+  });
+
+  it('rotates the angular half into the body frame, as mjlab does', () => {
+    // A free joint's qvel is world-frame linear + *body*-frame angular, but the term
+    // wrote both in the world frame. Skipping the rotation spins the body about the
+    // wrong axis for any orientation but identity.
+    const model = fakeModel(1);
+    const data = fakeData(model);
+    // 90 degrees about +z: (w, x, y, z) = (cos45, 0, 0, sin45).
+    const h = Math.SQRT1_2;
+    data.qpos.set([0, 0, 0, h, 0, 0, h], 0);
+    applyEntityWrite(model, data, { kind: 'root_velocity', fields: ['velocity'] }, {
+      root_velocity__velocity: new Float32Array([1, 0, 0, 2, 0, 0]),
+    });
+    // Linear stays world-frame; world +x angular reads as body -y after the inverse.
+    expect(Array.from(data.qvel.slice(0, 3))).toEqual([1, 0, 0].map(v => expect.closeTo(v, 6)));
+    expect(Array.from(data.qvel.slice(3, 6))).toEqual([0, -2, 0].map(v => expect.closeTo(v, 6)));
+  });
+
+  it('reads the orientation a pose written first left behind', () => {
+    // `write_root_state_to_sim` splits into pose then velocity, and mjlab reads the
+    // quaternion out of qpos — so the new pose is the frame, not the old one.
+    const model = fakeModel(1);
+    const data = fakeData(model);
+    const h = Math.SQRT1_2;
+    const applied = applyEntityWrites(
+      model,
+      data,
+      [
+        { kind: 'root_pose', entity: 'robot', fields: ['pose'] },
+        { kind: 'root_velocity', entity: 'robot', fields: ['velocity'] },
+      ],
+      {
+        root_pose__pose: new Float32Array([0, 0, 1, h, 0, 0, h]),
+        root_velocity__velocity: new Float32Array([0, 0, 0, 2, 0, 0]),
+      },
+    );
+    expect(applied).toBe(2);
+    expect(Array.from(data.qvel.slice(3, 6))).toEqual([0, -2, 0].map(v => expect.closeTo(v, 6)));
   });
 
   it('degrades (returns false) on a fixed-base model instead of throwing', () => {
@@ -261,14 +304,51 @@ describe('findEntityFreeJoint', () => {
     expect(findEntityFreeJoint(model, 'ball')).toBe(3);
   });
 
-  it('falls back to the first free joint without a name, or with an unknown one', () => {
-    const model = fakeSceneModel();
-    expect(findEntityFreeJoint(model, null)).toBe(0);
-    expect(findEntityFreeJoint(model, 'nobody')).toBe(0);
+  it('takes the first free joint when no entity is named', () => {
+    expect(findEntityFreeJoint(fakeSceneModel(), null)).toBe(0);
   });
 
-  it('falls back for a single-entity scene, whose names carry no prefix', () => {
+  it('owns nothing in a namespaced model that has no such entity', () => {
+    // Landing on the first free joint instead is how a thrown ball launches the robot,
+    // and mjlab would not get this far: `env.scene["nobody"]` raises.
+    expect(findEntityFreeJoint(fakeSceneModel(), 'nobody')).toBe(-1);
+  });
+
+  it('takes the one free joint of an unprefixed, single-entity scene', () => {
     expect(findEntityFreeJoint(fakeModel(2), 'robot')).toBe(0);
+  });
+});
+
+describe('applyEntityWrite: entity-prefixed outputs', () => {
+  it('reads each target\'s value through the outputs it declares', () => {
+    // Two entities, one kind: the values only tell them apart by name.
+    const model = fakeSceneModel();
+    const data = fakeData(model);
+    const applied = applyEntityWrites(
+      model,
+      data,
+      [
+        {
+          kind: 'root_pose',
+          entity: 'robot',
+          fields: ['pose'],
+          outputs: ['robot__root_pose__pose'],
+        },
+        {
+          kind: 'root_pose',
+          entity: 'ball',
+          fields: ['pose'],
+          outputs: ['ball__root_pose__pose'],
+        },
+      ],
+      {
+        robot__root_pose__pose: new Float32Array([0, 0, 0.8, 1, 0, 0, 0]),
+        ball__root_pose__pose: new Float32Array([2, 0.5, 1.8, 1, 0, 0, 0]),
+      },
+    );
+    expect(applied).toBe(2);
+    expect(data.qpos[2]).toBeCloseTo(0.8, 6);
+    expect(data.qpos[9]).toBeCloseTo(2, 6);
   });
 });
 

--- a/src/mjswan/template/src/core/event/__tests__/entityWrite.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/entityWrite.test.ts
@@ -8,7 +8,12 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { applyEntityWrite, applyEntityWrites, findFreeJoint } from '../entityWrite';
+import {
+  applyEntityWrite,
+  applyEntityWrites,
+  findEntityFreeJoint,
+  findFreeJoint,
+} from '../entityWrite';
 import type { WriteTarget } from '../entityWrite';
 
 type MjModel = import('mujoco').MjModel;
@@ -42,6 +47,46 @@ function fakeModel(nHinge: number, withFreeJoint = true): MjModel {
     jnt_dofadr: Int32Array.from(dofadr),
     names: new Uint8Array(0).buffer,
     name_jntadr: Int32Array.from(jntType.map(() => 0)),
+    _nq: q,
+    _nv: d,
+  } as unknown as MjModel;
+}
+
+/**
+ * A robot (free joint + `nHinge` hinges) followed by a free-floating ball, named as
+ * mjlab prefixes them: `robot/pelvis`, `ball/ball`.
+ */
+function fakeSceneModel(nHinge = 2): MjModel {
+  const jntType = [0, ...Array.from({ length: nHinge }, () => 3), 0];
+  const qposadr: number[] = [];
+  const dofadr: number[] = [];
+  let q = 0;
+  let d = 0;
+  for (const type of jntType) {
+    qposadr.push(q);
+    dofadr.push(d);
+    q += type === 0 ? 7 : 1;
+    d += type === 0 ? 6 : 1;
+  }
+  // One body per joint, plus the world body at index 0.
+  const bodyNames = ['world', 'robot/pelvis', ...Array.from({ length: nHinge }, (_, i) => `robot/link${i}`), 'ball/ball'];
+  const encoder = new TextEncoder();
+  const blob: number[] = [];
+  const bodyAdr: number[] = [];
+  for (const name of bodyNames) {
+    bodyAdr.push(blob.length);
+    blob.push(...encoder.encode(name), 0);
+  }
+  return {
+    njnt: jntType.length,
+    nbody: bodyNames.length,
+    jnt_type: Int32Array.from(jntType),
+    jnt_qposadr: Int32Array.from(qposadr),
+    jnt_dofadr: Int32Array.from(dofadr),
+    jnt_bodyid: Int32Array.from(jntType.map((_, j) => j + 1)),
+    names: Uint8Array.from(blob).buffer,
+    name_jntadr: Int32Array.from(jntType.map(() => 0)),
+    name_bodyadr: Int32Array.from(bodyAdr),
     _nq: q,
     _nv: d,
   } as unknown as MjModel;
@@ -206,5 +251,55 @@ describe('applyEntityWrites', () => {
     expect(applied).toBe(2);
     expect(data.qpos[0]).toBeCloseTo(0.4, 6);
     expect(data.qpos[3]).toBeCloseTo(1, 6);
+  });
+});
+
+describe('findEntityFreeJoint', () => {
+  it('finds the named entity\'s own free joint, not the first one', () => {
+    const model = fakeSceneModel();
+    expect(findEntityFreeJoint(model, 'robot')).toBe(0);
+    expect(findEntityFreeJoint(model, 'ball')).toBe(3);
+  });
+
+  it('falls back to the first free joint without a name, or with an unknown one', () => {
+    const model = fakeSceneModel();
+    expect(findEntityFreeJoint(model, null)).toBe(0);
+    expect(findEntityFreeJoint(model, 'nobody')).toBe(0);
+  });
+
+  it('falls back for a single-entity scene, whose names carry no prefix', () => {
+    expect(findEntityFreeJoint(fakeModel(2), 'robot')).toBe(0);
+  });
+});
+
+describe('applyEntityWrite: a second entity', () => {
+  // A thrown ball is the case: the event writes the ball's root, and landing it on the
+  // robot's instead launches the robot across the scene while the ball never moves.
+  it('writes the pose and velocity at the named entity\'s address', () => {
+    const model = fakeSceneModel();
+    const data = fakeData(model);
+    const applied = applyEntityWrites(
+      model,
+      data,
+      [
+        { kind: 'root_pose', entity: 'ball', fields: ['pose'] },
+        { kind: 'root_velocity', entity: 'ball', fields: ['velocity'] },
+      ],
+      {
+        root_pose__pose: new Float32Array([2, 0.5, 1.8, 1, 0, 0, 0]),
+        root_velocity__velocity: new Float32Array([-4, -1, 0, 0, 0, 0]),
+      },
+    );
+    expect(applied).toBe(2);
+    // The ball's free joint starts after the robot's 7 qpos + 2 hinges.
+    expect(Array.from(data.qpos.slice(9, 16))).toEqual(
+      [2, 0.5, 1.8, 1, 0, 0, 0].map(v => expect.closeTo(v, 6)),
+    );
+    expect(Array.from(data.qvel.slice(8, 14))).toEqual(
+      [-4, -1, 0, 0, 0, 0].map(v => expect.closeTo(v, 6)),
+    );
+    // The robot stayed where it was.
+    expect(Array.from(data.qpos.slice(0, 7))).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    expect(Array.from(data.qvel.slice(0, 6))).toEqual([0, 0, 0, 0, 0, 0]);
   });
 });

--- a/src/mjswan/template/src/core/event/entityWrite.ts
+++ b/src/mjswan/template/src/core/event/entityWrite.ts
@@ -12,32 +12,31 @@ export type WriteKind = 'joint_state' | 'root_pose' | 'root_velocity';
 
 export interface WriteTarget {
   kind: WriteKind;
-  /** Entity the write applies to. A scene with two of them (a robot and a thrown ball)
-   * has a free joint each, and the first one is not always the right one. */
+  /** Entity the write applies to. One term may write several — mjlab resolves each
+   * entity's own addresses — and the model's first free joint is not always the one. */
   entity?: string | null;
   fields: string[];
-  /** Resolved joint indices for `joint_state`; `"all"` means every joint. */
-  joint_ids?: number[] | 'all';
+  /** Graph outputs holding `fields`, in the same order. Absent in bundles built before
+   * a term could write two entities, whose outputs are named `"<kind>__<field>"`. */
+  outputs?: string[];
+  /** Resolved joint indices for `joint_state`; `"all"` (or absent) means every joint. */
+  joint_ids?: number[] | 'all' | null;
 }
 
-/** Graph outputs keyed by the tracer's `"<kind>__<field>"` naming. */
+/** Graph outputs, keyed as `WriteTarget.outputs` names them. */
 export type WriteValues = Record<string, Float32Array | Float64Array | number[]>;
 
-function decodeNames(mjModel: MjModel, addresses: Int32Array, count: number): string[] {
+export function decodeJointNames(mjModel: MjModel): string[] {
   const bytes = new Uint8Array(mjModel.names);
   const decoder = new TextDecoder();
   const names: string[] = [];
-  for (let i = 0; i < count; i++) {
-    const start = addresses[i];
+  for (let j = 0; j < mjModel.njnt; j++) {
+    const start = mjModel.name_jntadr[j];
     let end = start;
     while (end < bytes.length && bytes[end] !== 0) end++;
     names.push(decoder.decode(bytes.subarray(start, end)));
   }
   return names;
-}
-
-export function decodeJointNames(mjModel: MjModel): string[] {
-  return decodeNames(mjModel, mjModel.name_jntadr, mjModel.njnt);
 }
 
 export function findFreeJoint(mjModel: MjModel): number {
@@ -48,22 +47,57 @@ export function findFreeJoint(mjModel: MjModel): number {
 }
 
 /**
- * The free joint carrying `entity`'s root, or the model's first one.
+ * Which of `entity`'s joints a write reaches, by mjlab's rule: it resolves an entity's
+ * addresses from that entity's own spec joints, whose names it namespaces `entity/…`.
  *
- * mjlab prefixes an entity's elements with its name, so the owner of a free joint is the
- * prefix on its body. Falling back to the first free joint covers the single-entity
- * scene, whose names carry no prefix at all — the same rule `entityJointIds` follows —
- * and a model that carries no body names to read.
+ * An unprefixed model is a single-entity scene, where every joint is the entity's — the
+ * hand-built scenes mjswan also serves. A *prefixed* model with no such entity owns
+ * nothing the write belongs to, so it gets nothing: mjlab would raise on the scene
+ * lookup, and landing on another entity is how a thrown ball launches the robot.
  */
+function entityJoints(
+  mjModel: MjModel,
+  entity: string | null | undefined,
+  candidates: number[],
+): number[] {
+  if (!entity) return candidates;
+  const names = decodeJointNames(mjModel);
+  const owned = candidates.filter(j => names[j].startsWith(`${entity}/`));
+  if (owned.length > 0) return owned;
+  return names.some(name => name.includes('/')) ? [] : candidates;
+}
+
+/** The free joint carrying `entity`'s root, or -1 when the model holds none of its own. */
 export function findEntityFreeJoint(mjModel: MjModel, entity?: string | null): number {
-  if (!entity || !mjModel.name_bodyadr || !mjModel.jnt_bodyid) return findFreeJoint(mjModel);
-  const bodies = decodeNames(mjModel, mjModel.name_bodyadr, mjModel.nbody);
+  const free: number[] = [];
   for (let j = 0; j < mjModel.njnt; j++) {
-    if (mjModel.jnt_type[j] !== 0) continue; // mjJNT_FREE
-    const body = bodies[mjModel.jnt_bodyid[j]] ?? '';
-    if (body === entity || body.startsWith(`${entity}/`)) return j;
+    if (mjModel.jnt_type[j] === 0) free.push(j); // mjJNT_FREE
   }
-  return findFreeJoint(mjModel);
+  return entityJoints(mjModel, entity, free)[0] ?? -1;
+}
+
+/**
+ * What `joint_ids` indexes: the entity's 1-DoF joints in model order, as mjlab's
+ * `Entity.joint_names` lists them. The model's own joint list is not the same — it
+ * includes the free joint, whose `qpos[0]` is the root's x, not an angle.
+ */
+function entityJointIds(mjModel: MjModel, entity: string | null | undefined): number[] {
+  const hinges: number[] = [];
+  for (let j = 0; j < mjModel.njnt; j++) {
+    if (mjModel.jnt_type[j] >= 2) hinges.push(j); // not mjJNT_FREE / mjJNT_BALL
+  }
+  return entityJoints(mjModel, entity, hinges);
+}
+
+/** The value a target's `field` was written with, or undefined. */
+function writtenValue(
+  target: WriteTarget,
+  values: WriteValues,
+  field: string,
+): WriteValues[string] | undefined {
+  const index = target.fields?.indexOf(field) ?? -1;
+  const key = (index >= 0 ? target.outputs?.[index] : undefined) ?? `${target.kind}__${field}`;
+  return values[key];
 }
 
 /**
@@ -80,9 +114,14 @@ export function applyEntityWrite(
     case 'joint_state':
       return writeJointState(mjModel, mjData, target, values);
     case 'root_pose':
-      return writeRootPose(mjModel, mjData, target, values['root_pose__pose']);
+      return writeRootPose(mjModel, mjData, target, writtenValue(target, values, 'pose'));
     case 'root_velocity':
-      return writeRootVelocity(mjModel, mjData, target, values['root_velocity__velocity']);
+      return writeRootVelocity(
+        mjModel,
+        mjData,
+        target,
+        writtenValue(target, values, 'velocity'),
+      );
     default:
       return false;
   }
@@ -102,27 +141,10 @@ export function applyEntityWrites(
   return applied;
 }
 
-/**
- * What `joint_ids` indexes: the entity's 1-DoF joints in model order, as mjlab's
- * `Entity.joint_names` lists them. The model's own joint list is not the same — it
- * includes the free joint, whose `qpos[0]` is the root's x, not an angle.
- */
-function entityJointIds(mjModel: MjModel, entity: string | null | undefined): number[] {
-  const ids: number[] = [];
-  for (let j = 0; j < mjModel.njnt; j++) {
-    if (mjModel.jnt_type[j] >= 2) ids.push(j); // not mjJNT_FREE / mjJNT_BALL
-  }
-  if (!entity) return ids;
-  const names = decodeJointNames(mjModel);
-  const owned = ids.filter(j => names[j].startsWith(`${entity}/`));
-  // Unprefixed names mean a single-entity scene, where every joint is the entity's.
-  return owned.length > 0 ? owned : ids;
-}
-
 function resolveJointIds(mjModel: MjModel, target: WriteTarget): number[] {
   const all = entityJointIds(mjModel, target.entity);
   const ids = target.joint_ids;
-  if (ids === undefined || ids === 'all') return all;
+  if (ids === undefined || ids === null || ids === 'all') return all;
   return ids.map(i => all[i] ?? -1);
 }
 
@@ -132,21 +154,24 @@ function writeJointState(
   target: WriteTarget,
   values: WriteValues,
 ): boolean {
-  const position = values['joint_state__position'];
-  const velocity = values['joint_state__velocity'];
+  const position = writtenValue(target, values, 'position');
+  const velocity = writtenValue(target, values, 'velocity');
   if (!position && !velocity) return false;
+  let wrote = 0;
   const jointIds = resolveJointIds(mjModel, target);
   for (let i = 0; i < jointIds.length; i++) {
     const j = jointIds[i];
     if (j < 0 || j >= mjModel.njnt) continue;
     if (position && i < position.length) {
       mjData.qpos[mjModel.jnt_qposadr[j]] = position[i];
+      wrote++;
     }
     if (velocity && i < velocity.length) {
       mjData.qvel[mjModel.jnt_dofadr[j]] = velocity[i];
+      wrote++;
     }
   }
-  return true;
+  return wrote > 0;
 }
 
 function writeRootPose(
@@ -163,6 +188,32 @@ function writeRootPose(
   return true;
 }
 
+/** Rotate `v` by the conjugate of the (w, x, y, z) quaternion `q` — mjlab's `quat_apply_inverse`. */
+function rotateByQuatInverse(
+  q: ArrayLike<number>,
+  qAdr: number,
+  v: ArrayLike<number>,
+  vAdr: number,
+): [number, number, number] {
+  // Conjugate, so the rotation runs world -> body.
+  const w = q[qAdr];
+  const x = -q[qAdr + 1];
+  const y = -q[qAdr + 2];
+  const z = -q[qAdr + 3];
+  const vx = v[vAdr];
+  const vy = v[vAdr + 1];
+  const vz = v[vAdr + 2];
+  // v' = v + w * t + u x t, with t = 2 * (u x v) and u = (x, y, z).
+  const tx = 2 * (y * vz - z * vy);
+  const ty = 2 * (z * vx - x * vz);
+  const tz = 2 * (x * vy - y * vx);
+  return [
+    vx + w * tx + (y * tz - z * ty),
+    vy + w * ty + (z * tx - x * tz),
+    vz + w * tz + (x * ty - y * tx),
+  ];
+}
+
 function writeRootVelocity(
   mjModel: MjModel,
   mjData: MjData,
@@ -172,7 +223,13 @@ function writeRootVelocity(
   if (!velocity || velocity.length < 6) return false;
   const j = findEntityFreeJoint(mjModel, target.entity);
   if (j < 0) return false;
+  // A free joint's qvel holds world-frame linear and *body*-frame angular velocity, while
+  // the term wrote both in the world frame, as mjlab's `write_root_velocity` takes them.
+  // The quaternion comes from qpos, so a pose written first is the one used — mjlab's
+  // order too, and what `write_root_state_to_sim` splits into.
+  const angB = rotateByQuatInverse(mjData.qpos, mjModel.jnt_qposadr[j] + 3, velocity, 3);
   const adr = mjModel.jnt_dofadr[j];
-  for (let i = 0; i < 6; i++) mjData.qvel[adr + i] = velocity[i];
+  for (let i = 0; i < 3; i++) mjData.qvel[adr + i] = velocity[i];
+  for (let i = 0; i < 3; i++) mjData.qvel[adr + 3 + i] = angB[i];
   return true;
 }

--- a/src/mjswan/template/src/core/event/entityWrite.ts
+++ b/src/mjswan/template/src/core/event/entityWrite.ts
@@ -12,7 +12,8 @@ export type WriteKind = 'joint_state' | 'root_pose' | 'root_velocity';
 
 export interface WriteTarget {
   kind: WriteKind;
-  /** Entity the write applies to (informational at N=1, single-entity scenes). */
+  /** Entity the write applies to. A scene with two of them (a robot and a thrown ball)
+   * has a free joint each, and the first one is not always the right one. */
   entity?: string | null;
   fields: string[];
   /** Resolved joint indices for `joint_state`; `"all"` means every joint. */
@@ -22,12 +23,12 @@ export interface WriteTarget {
 /** Graph outputs keyed by the tracer's `"<kind>__<field>"` naming. */
 export type WriteValues = Record<string, Float32Array | Float64Array | number[]>;
 
-export function decodeJointNames(mjModel: MjModel): string[] {
+function decodeNames(mjModel: MjModel, addresses: Int32Array, count: number): string[] {
   const bytes = new Uint8Array(mjModel.names);
   const decoder = new TextDecoder();
   const names: string[] = [];
-  for (let j = 0; j < mjModel.njnt; j++) {
-    const start = mjModel.name_jntadr[j];
+  for (let i = 0; i < count; i++) {
+    const start = addresses[i];
     let end = start;
     while (end < bytes.length && bytes[end] !== 0) end++;
     names.push(decoder.decode(bytes.subarray(start, end)));
@@ -35,11 +36,34 @@ export function decodeJointNames(mjModel: MjModel): string[] {
   return names;
 }
 
+export function decodeJointNames(mjModel: MjModel): string[] {
+  return decodeNames(mjModel, mjModel.name_jntadr, mjModel.njnt);
+}
+
 export function findFreeJoint(mjModel: MjModel): number {
   for (let j = 0; j < mjModel.njnt; j++) {
     if (mjModel.jnt_type[j] === 0) return j; // mjJNT_FREE
   }
   return -1;
+}
+
+/**
+ * The free joint carrying `entity`'s root, or the model's first one.
+ *
+ * mjlab prefixes an entity's elements with its name, so the owner of a free joint is the
+ * prefix on its body. Falling back to the first free joint covers the single-entity
+ * scene, whose names carry no prefix at all — the same rule `entityJointIds` follows —
+ * and a model that carries no body names to read.
+ */
+export function findEntityFreeJoint(mjModel: MjModel, entity?: string | null): number {
+  if (!entity || !mjModel.name_bodyadr || !mjModel.jnt_bodyid) return findFreeJoint(mjModel);
+  const bodies = decodeNames(mjModel, mjModel.name_bodyadr, mjModel.nbody);
+  for (let j = 0; j < mjModel.njnt; j++) {
+    if (mjModel.jnt_type[j] !== 0) continue; // mjJNT_FREE
+    const body = bodies[mjModel.jnt_bodyid[j]] ?? '';
+    if (body === entity || body.startsWith(`${entity}/`)) return j;
+  }
+  return findFreeJoint(mjModel);
 }
 
 /**
@@ -56,9 +80,9 @@ export function applyEntityWrite(
     case 'joint_state':
       return writeJointState(mjModel, mjData, target, values);
     case 'root_pose':
-      return writeRootPose(mjModel, mjData, values['root_pose__pose']);
+      return writeRootPose(mjModel, mjData, target, values['root_pose__pose']);
     case 'root_velocity':
-      return writeRootVelocity(mjModel, mjData, values['root_velocity__velocity']);
+      return writeRootVelocity(mjModel, mjData, target, values['root_velocity__velocity']);
     default:
       return false;
   }
@@ -128,10 +152,11 @@ function writeJointState(
 function writeRootPose(
   mjModel: MjModel,
   mjData: MjData,
+  target: WriteTarget,
   pose: WriteValues[string] | undefined,
 ): boolean {
   if (!pose || pose.length < 7) return false;
-  const j = findFreeJoint(mjModel);
+  const j = findEntityFreeJoint(mjModel, target.entity);
   if (j < 0) return false;
   const adr = mjModel.jnt_qposadr[j];
   for (let i = 0; i < 7; i++) mjData.qpos[adr + i] = pose[i];
@@ -141,10 +166,11 @@ function writeRootPose(
 function writeRootVelocity(
   mjModel: MjModel,
   mjData: MjData,
+  target: WriteTarget,
   velocity: WriteValues[string] | undefined,
 ): boolean {
   if (!velocity || velocity.length < 6) return false;
-  const j = findFreeJoint(mjModel);
+  const j = findEntityFreeJoint(mjModel, target.entity);
   if (j < 0) return false;
   const adr = mjModel.jnt_dofadr[j];
   for (let i = 0; i < 6; i++) mjData.qvel[adr + i] = velocity[i];

--- a/src/mjswan/template/src/core/observation/HistoryObservation.ts
+++ b/src/mjswan/template/src/core/observation/HistoryObservation.ts
@@ -4,16 +4,18 @@
  * `PolicyRunner`'s group-level buffer would give step-major order. That is also why a
  * group with per-term history does not fuse.
  *
- * `offsets` generalises the count: dense `history_length: n` arrives as `[0..n-1]`, and
- * a policy trained on sparse look-back names its offsets directly. The buffer holds
- * `max(offsets) + 1` frames; only the named ones reach the output.
+ * `offsets` generalises the count: dense `history_length: n` arrives as `[n-1..0]`, the
+ * chronological stack mjlab's history buffer flattens, and a policy trained on a sparse
+ * or reversed window names its offsets directly. The buffer holds `max(offsets) + 1`
+ * frames; only the named ones reach the output.
  */
 
 import { ObservationBase, type ObservationConfig } from './ObservationBase';
 import type { PolicyState } from '../policy/types';
 import type { PolicyRunner } from '../policy/PolicyRunner';
 
-/** Write `frame` element-major at slot `index` of `count`: `[a_t, a_{t-1}, …, b_t, …]`. */
+/** Write `frame` element-major at slot `index` of `count`: `[a_0, a_1, …, b_0, …]`, each
+ * element's own frames adjacent. */
 export function writeInterleavedFrame(
   out: Float32Array,
   frame: Float32Array,
@@ -33,7 +35,8 @@ export function historyOffsets(entry: ObservationConfig): number[] | null {
   }
   const length = Math.trunc(Number((entry as { history_length?: unknown }).history_length) || 0);
   if (length <= 1) return null;
-  return Array.from({ length }, (_, i) => i);
+  // Oldest frame first, as mjlab's `CircularBuffer.buffer` flattens it.
+  return Array.from({ length }, (_, i) => length - 1 - i);
 }
 
 export class HistoryObservation extends ObservationBase {
@@ -94,7 +97,7 @@ export class HistoryObservation extends ObservationBase {
     return this.gather();
   }
 
-  /** Frame-major (`[frame_t, frame_{t-1}, …]`), or element-major when interleaved. */
+  /** Frame-major, one full vector per offset in order, or element-major when interleaved. */
   private gather(): Float32Array {
     const width = this.base.size;
     const out = new Float32Array(width * this.offsets.length);

--- a/src/mjswan/template/src/core/observation/__tests__/HistoryObservation.test.ts
+++ b/src/mjswan/template/src/core/observation/__tests__/HistoryObservation.test.ts
@@ -4,8 +4,9 @@
  *
  * The cases that matter are the ones a wrong buffer makes *plausible* rather than
  * obviously broken: the offset→frame mapping (an off-by-one reads last step's value
- * forever), priming after a reset (a history of zeros the policy never saw in
- * training), and sparse offsets sizing the term by the offsets they name rather
+ * forever), the direction a dense count stacks in (reversing it keeps the width and
+ * runs time backwards), priming after a reset (a history of zeros the policy never saw
+ * in training), and sparse offsets sizing the term by the offsets they name rather
  * than by how far back they reach.
  */
 import { describe, expect, it } from 'vitest';
@@ -45,8 +46,8 @@ function build(config: ObservationConfig): { history: HistoryObservation; base: 
 }
 
 describe('historyOffsets', () => {
-  it('expands a dense length into consecutive offsets', () => {
-    expect(historyOffsets({ name: 'x', history_length: 3 })).toEqual([0, 1, 2]);
+  it('expands a dense length oldest-frame-first, as mjlab flattens its buffer', () => {
+    expect(historyOffsets({ name: 'x', history_length: 3 })).toEqual([2, 1, 0]);
   });
 
   it('treats no history and a single frame alike — nothing to stack', () => {
@@ -73,12 +74,18 @@ describe('HistoryObservation', () => {
     expect(Array.from(await history.compute(STATE))).toEqual([1, 10, 1, 10, 1, 10]);
   });
 
-  it('shifts frame-major, newest first', async () => {
+  it('shifts frame-major, oldest first', async () => {
     const { history } = build({ name: 'x', history_length: 3 });
     await history.compute(STATE);
-    expect(Array.from(await history.compute(STATE))).toEqual([2, 20, 1, 10, 1, 10]);
-    expect(Array.from(await history.compute(STATE))).toEqual([3, 30, 2, 20, 1, 10]);
-    // Frame 1 has now fallen off the end of a 3-deep buffer.
+    expect(Array.from(await history.compute(STATE))).toEqual([1, 10, 1, 10, 2, 20]);
+    expect(Array.from(await history.compute(STATE))).toEqual([1, 10, 2, 20, 3, 30]);
+    // Frame 1 has now fallen off the start of a 3-deep buffer.
+    expect(Array.from(await history.compute(STATE))).toEqual([2, 20, 3, 30, 4, 40]);
+  });
+
+  it('takes a newest-first stack from offsets, which a count no longer spells', async () => {
+    const { history } = build({ name: 'x', history_offsets: [0, 1, 2] });
+    for (let i = 0; i < 3; i++) await history.compute(STATE);
     expect(Array.from(await history.compute(STATE))).toEqual([4, 40, 3, 30, 2, 20]);
   });
 
@@ -101,7 +108,7 @@ describe('HistoryObservation', () => {
   it('lays the stack out element-major when interleaved', async () => {
     const { history } = build({ name: 'x', history_length: 2, history_interleaved: true });
     await history.compute(STATE);
-    // [e0_t, e0_t-1, e1_t, e1_t-1] rather than [e0_t, e1_t, e0_t-1, e1_t-1].
-    expect(Array.from(await history.compute(STATE))).toEqual([2, 1, 20, 10]);
+    // [e0_t-1, e0_t, e1_t-1, e1_t] rather than [e0_t-1, e1_t-1, e0_t, e1_t].
+    expect(Array.from(await history.compute(STATE))).toEqual([1, 2, 10, 20]);
   });
 });

--- a/src/mjswan/template/src/core/policy/PolicyRunner.ts
+++ b/src/mjswan/template/src/core/policy/PolicyRunner.ts
@@ -162,10 +162,10 @@ export class PolicyRunner {
           for (let i = 0; i < history.steps; i++) buffer.set(frame, i * frame.length);
           delete this.historyNeedsPrime[key];
         } else {
-          for (let i = buffer.length - 1; i >= frame.length; i--) {
-            buffer[i] = buffer[i - frame.length];
-          }
-          buffer.set(frame, 0);
+          // Shift the oldest frame out the front; the newest lands last, the order
+          // `history_length` and `HistoryObservation` use.
+          buffer.copyWithin(0, frame.length);
+          buffer.set(frame, buffer.length - frame.length);
         }
         // The buffer is frame-major either way; interleaving is an output layout.
         outputs[key] = history.interleaved

--- a/src/mjswan/template/src/core/policy/__tests__/groupHistory.test.ts
+++ b/src/mjswan/template/src/core/policy/__tests__/groupHistory.test.ts
@@ -2,9 +2,9 @@
  * `PolicyRunner`'s group-level frame stack: the `{components, history_steps,
  * interleaved}` config shape a hand-authored `policy.json` can declare.
  *
- * Both layouts are the same length, so getting `interleaved` wrong reaches the policy
- * as reordered numbers rather than as a size error — hence a test per layout, and one
- * pinning the group stack against the per-term one.
+ * Both layouts are the same length, so getting `interleaved` — or the direction the
+ * stack grows in — wrong reaches the policy as reordered numbers rather than as a size
+ * error, hence a test per layout and one pinning the size.
  */
 import { describe, expect, it } from 'vitest';
 
@@ -53,18 +53,18 @@ async function collect(instance: PolicyRunner): Promise<number[]> {
 }
 
 describe('PolicyRunner group history', () => {
-  it('stacks frame-major by default', async () => {
+  it('stacks frame-major, oldest first, as a per-term stack does', async () => {
     const instance = await runner(false);
     // Primed: every slot holds frame 1.
     expect(await collect(instance)).toEqual([1, 10, 1, 10]);
-    expect(await collect(instance)).toEqual([2, 20, 1, 10]);
+    expect(await collect(instance)).toEqual([1, 10, 2, 20]);
   });
 
   it('lays the stack out element-major when interleaved', async () => {
     const instance = await runner(true);
     expect(await collect(instance)).toEqual([1, 1, 10, 10]);
-    // [e0_t, e0_t-1, e1_t, e1_t-1] rather than [e0_t, e1_t, e0_t-1, e1_t-1].
-    expect(await collect(instance)).toEqual([2, 1, 20, 10]);
+    // [e0_t-1, e0_t, e1_t-1, e1_t] rather than [e0_t-1, e1_t-1, e0_t, e1_t].
+    expect(await collect(instance)).toEqual([1, 2, 10, 20]);
   });
 
   it('keeps the group size the same either way', async () => {

--- a/tests/test_mjlab_adapter.py
+++ b/tests/test_mjlab_adapter.py
@@ -177,12 +177,7 @@ class TestAdaptObservations:
         assert term.params == {"world_frame": True}
 
     def test_mjlab_obs_scale_and_history(self):
-        """mjlab's dense stack arrives as its offsets: oldest frame first.
-
-        mjlab flattens the term's buffer chronologically, so a bare `history_length=3`
-        — which mjswan reads newest-first — would hand the policy its history reversed:
-        the same width, the same numbers, time running backwards.
-        """
+        """A count carries over as a count: both sides stack oldest frame first."""
         mjlab_func = _make_mjlab_obs_func("joint_pos_rel")
         mjlab_term = FakeMjlabObsTermCfg(func=mjlab_func, scale=0.5, history_length=3)
         mjlab_group = FakeMjlabObsGroupCfg(terms={"jp": mjlab_term})
@@ -191,11 +186,12 @@ class TestAdaptObservations:
         assert result is not None
         term = result["policy"].terms["jp"]
         assert term.scale == 0.5
-        assert term.history_steps == (2, 1, 0)
+        assert term.history_length == 3
+        assert term.history_steps is None
 
-    def test_mjlab_group_history_reaches_every_term(self):
-        """A group-level count overrides the terms', as mjlab's manager does — and the
-        adapted group keeps no count of its own, so nothing can apply it twice."""
+    def test_mjlab_group_history_carries_over(self):
+        """The group's own count stays on the group, where the serializer applies it to
+        every term — as mjlab's manager does."""
         mjlab_group = FakeMjlabObsGroupCfg(
             terms={
                 "jp": FakeMjlabObsTermCfg(func=_make_mjlab_obs_func("joint_pos_rel")),
@@ -209,24 +205,8 @@ class TestAdaptObservations:
         result = adapt_observations({"policy": mjlab_group})
         assert result is not None
         group = result["policy"]
-        assert group.history_length is None
-        assert group.terms["jp"].history_steps == (3, 2, 1, 0)
-        assert group.terms["jv"].history_steps == (3, 2, 1, 0)
-
-    def test_mjlab_single_frame_history_is_no_history(self):
-        """`history_length=1` is a one-frame buffer: the term's own width, unstacked."""
-        mjlab_group = FakeMjlabObsGroupCfg(
-            terms={
-                "jp": FakeMjlabObsTermCfg(func=_make_mjlab_obs_func("joint_pos_rel"))
-            },
-            history_length=1,
-        )
-
-        result = adapt_observations({"policy": mjlab_group})
-        assert result is not None
-        term = result["policy"].terms["jp"]
-        assert term.history_steps is None
-        assert term.history_length == 0
+        assert group.history_length == 4
+        assert group.terms["jv"].history_length == 2
 
     def test_mjlab_cfg_subclass_is_still_adapted(self):
         """A task subclassing an mjlab config to add a field of its own is still mjlab.
@@ -250,7 +230,7 @@ class TestAdaptObservations:
         assert result is not None
         assert isinstance(result["policy"], ObservationGroupCfg)
         assert isinstance(result["policy"].terms["jp"], ObservationTermCfg)
-        assert result["policy"].terms["jp"].history_steps == (3, 2, 1, 0)
+        assert result["policy"].history_length == 4
 
     def test_mjlab_asset_cfg_kept_intact_for_tracing(self):
         # A plain (non-Binding) func is traced to ONNX at build time (ADR 0005) via `func(env,

--- a/tests/test_mjlab_adapter.py
+++ b/tests/test_mjlab_adapter.py
@@ -177,6 +177,12 @@ class TestAdaptObservations:
         assert term.params == {"world_frame": True}
 
     def test_mjlab_obs_scale_and_history(self):
+        """mjlab's dense stack arrives as its offsets: oldest frame first.
+
+        mjlab flattens the term's buffer chronologically, so a bare `history_length=3`
+        — which mjswan reads newest-first — would hand the policy its history reversed:
+        the same width, the same numbers, time running backwards.
+        """
         mjlab_func = _make_mjlab_obs_func("joint_pos_rel")
         mjlab_term = FakeMjlabObsTermCfg(func=mjlab_func, scale=0.5, history_length=3)
         mjlab_group = FakeMjlabObsGroupCfg(terms={"jp": mjlab_term})
@@ -185,7 +191,66 @@ class TestAdaptObservations:
         assert result is not None
         term = result["policy"].terms["jp"]
         assert term.scale == 0.5
-        assert term.history_length == 3
+        assert term.history_steps == (2, 1, 0)
+
+    def test_mjlab_group_history_reaches_every_term(self):
+        """A group-level count overrides the terms', as mjlab's manager does — and the
+        adapted group keeps no count of its own, so nothing can apply it twice."""
+        mjlab_group = FakeMjlabObsGroupCfg(
+            terms={
+                "jp": FakeMjlabObsTermCfg(func=_make_mjlab_obs_func("joint_pos_rel")),
+                "jv": FakeMjlabObsTermCfg(
+                    func=_make_mjlab_obs_func("joint_vel_rel"), history_length=2
+                ),
+            },
+            history_length=4,
+        )
+
+        result = adapt_observations({"policy": mjlab_group})
+        assert result is not None
+        group = result["policy"]
+        assert group.history_length is None
+        assert group.terms["jp"].history_steps == (3, 2, 1, 0)
+        assert group.terms["jv"].history_steps == (3, 2, 1, 0)
+
+    def test_mjlab_single_frame_history_is_no_history(self):
+        """`history_length=1` is a one-frame buffer: the term's own width, unstacked."""
+        mjlab_group = FakeMjlabObsGroupCfg(
+            terms={
+                "jp": FakeMjlabObsTermCfg(func=_make_mjlab_obs_func("joint_pos_rel"))
+            },
+            history_length=1,
+        )
+
+        result = adapt_observations({"policy": mjlab_group})
+        assert result is not None
+        term = result["policy"].terms["jp"]
+        assert term.history_steps is None
+        assert term.history_length == 0
+
+    def test_mjlab_cfg_subclass_is_still_adapted(self):
+        """A task subclassing an mjlab config to add a field of its own is still mjlab.
+
+        The subclass reports its own module, so a check on the class alone passes it
+        through unadapted — and the mjlab *terms* inside it then reach the serializer,
+        which fails on the first mjswan-only field.
+        """
+
+        class TaskObsGroupCfg(FakeMjlabObsGroupCfg):  # defined here, not in mjlab
+            pass
+
+        group = TaskObsGroupCfg(
+            terms={
+                "jp": FakeMjlabObsTermCfg(func=_make_mjlab_obs_func("joint_pos_rel"))
+            },
+            history_length=4,
+        )
+
+        result = adapt_observations({"policy": group})
+        assert result is not None
+        assert isinstance(result["policy"], ObservationGroupCfg)
+        assert isinstance(result["policy"].terms["jp"], ObservationTermCfg)
+        assert result["policy"].terms["jp"].history_steps == (3, 2, 1, 0)
 
     def test_mjlab_asset_cfg_kept_intact_for_tracing(self):
         # A plain (non-Binding) func is traced to ONNX at build time (ADR 0005) via `func(env,

--- a/tests/test_observation_history.py
+++ b/tests/test_observation_history.py
@@ -10,7 +10,7 @@ group carrying per-term history must not fuse: a fused graph emits one
 concatenation, which the runtime could only stack whole, giving step-major order
 where mjlab gives term-major.
 
-The runtime half of the contract (offset → frame, priming, layout) is pinned in
+The runtime half of the contract (offset → frame, order, priming, layout) is pinned in
 `core/observation/__tests__/HistoryObservation.test.ts`.
 """
 
@@ -68,6 +68,14 @@ def test_group_history_overrides_a_terms_own_length():
     assert _entry(_term(history_length=2), group_history=5)["history_length"] == 5
 
 
+def test_a_group_zero_switches_history_off():
+    """mjlab assigns the group's count whenever it is set, so an explicit 0 is an
+    instruction, not an absent value."""
+    entry = _entry(_term(history_length=4), group_history=0)
+    assert "history_length" not in entry
+    assert "history_offsets" not in entry
+
+
 def test_interleaved_only_ships_alongside_history():
     """It describes a stack's layout, so without a stack it says nothing."""
     assert "history_interleaved" not in _entry(_term(history_interleaved=True))
@@ -103,3 +111,8 @@ def test_only_a_stackless_group_fuses(term_cfg, fusable):
 def test_group_level_history_also_blocks_fusion():
     group = ObservationGroupCfg(terms={"a": _term()}, history_length=3)
     assert _group_is_fusable(group) is False
+
+
+def test_a_group_zero_lets_a_stacking_term_fuse():
+    group = ObservationGroupCfg(terms={"a": _term(history_length=4)}, history_length=0)
+    assert _group_is_fusable(group) is True

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -727,7 +727,7 @@ class TestWriteTargetEntity:
         )
 
     def test_the_write_names_the_entity_it_was_made_on(self):
-        import torch
+        torch = pytest.importorskip("torch")
 
         def throw(env, env_ids, ball_name="ball"):
             ball = env.scene[ball_name]
@@ -742,7 +742,8 @@ class TestWriteTargetEntity:
 
     def test_an_asset_cfg_still_names_it(self):
         """mjlab's own convention keeps working, and stays the fallback."""
-        import torch
+        torch = pytest.importorskip("torch")
+        pytest.importorskip("mjlab")
         from mjlab.managers.scene_entity_config import SceneEntityCfg
 
         def reset(env, env_ids, asset_cfg=None):
@@ -755,7 +756,7 @@ class TestWriteTargetEntity:
 
     def test_two_entities_writing_one_kind_is_refused(self):
         """One write per kind reaches the browser, so silently dropping one is worse."""
-        import torch
+        torch = pytest.importorskip("torch")
 
         def throw_both(env, env_ids):
             for name in ("ball", "robot"):

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -678,14 +678,14 @@ class TestFlatPatchSpawnTraces:
 
 
 class TestWriteTargetEntity:
-    """Which entity a traced write lands on.
+    """Which entity a traced write lands on, and how many it may land on.
 
     The browser resolves a root write through this name, and a scene with two floating
     bodies — a robot and a thrown ball — has a free joint each. Reading the name off an
     `asset_cfg` param only is what left it `null`: mjlab's own terms take that param, but
     a task's term is free to take a plain `ball_name`, and then the write went to
     whichever free joint came first in the model. The robot got launched; the ball never
-    moved.
+    moved. mjlab writes per entity, so the tracer keys captures the same way.
     """
 
     @staticmethod
@@ -695,18 +695,29 @@ class TestWriteTargetEntity:
         class _Data:
             def __init__(self):
                 self.root_link_pos_w = torch.zeros(1, 3)
+                self.default_root_state = torch.zeros(1, 13)
 
         class _Entity:
             def __init__(self):
                 self.data = _Data()
+                self.written = 0
 
-            def write_root_link_pose_to_sim(self, pose, env_ids=None): ...
+            def write_root_link_pose_to_sim(self, pose, env_ids=None):
+                self.written += 1
 
-            def write_root_link_velocity_to_sim(self, velocity, env_ids=None): ...
+            def write_root_link_velocity_to_sim(self, velocity, env_ids=None):
+                self.written += 1
+
+            def write_root_state_to_sim(self, root_state, env_ids=None):
+                self.written += 1
 
         class _Scene(dict):
             def __getitem__(self, name):
                 return self.setdefault(name, _Entity())
+
+            @property
+            def entities(self):
+                return {name: self[name] for name in ("robot", "ball")}
 
         class _Env:
             def __init__(self):
@@ -717,13 +728,17 @@ class TestWriteTargetEntity:
         return _Env()
 
     @staticmethod
-    def _trace(func, params):
+    def _trace(func, params, env=None):
         pytest.importorskip("mjlab")
         pytest.importorskip("torch")
         from mjswan.compile import trace_event_term
 
         return trace_event_term(
-            func, params, TestWriteTargetEntity._env(), name="throw", mode="interval"
+            func,
+            params,
+            env if env is not None else TestWriteTargetEntity._env(),
+            name="throw",
+            mode="interval",
         )
 
     def test_the_write_names_the_entity_it_was_made_on(self):
@@ -738,6 +753,15 @@ class TestWriteTargetEntity:
         assert [(w["kind"], w["entity"]) for w in export.write_targets] == [
             ("root_pose", "ball"),
             ("root_velocity", "ball"),
+        ]
+        # The graph output carries the entity too, so a second one cannot collide.
+        assert [w["outputs"] for w in export.write_targets] == [
+            ["ball__root_pose__pose"],
+            ["ball__root_velocity__velocity"],
+        ]
+        assert export.output_names == [
+            "ball__root_pose__pose",
+            "ball__root_velocity__velocity",
         ]
 
     def test_an_asset_cfg_still_names_it(self):
@@ -754,8 +778,9 @@ class TestWriteTargetEntity:
         export = self._trace(reset, {"asset_cfg": SceneEntityCfg("robot")})
         assert [w["entity"] for w in export.write_targets] == ["robot"]
 
-    def test_two_entities_writing_one_kind_is_refused(self):
-        """One write per kind reaches the browser, so silently dropping one is worse."""
+    def test_two_entities_each_get_their_own_target(self):
+        """One write per entity reaches the browser, as in mjlab — the robot's root and
+        the ball's are different addresses."""
         torch = pytest.importorskip("torch")
 
         def throw_both(env, env_ids):
@@ -764,8 +789,63 @@ class TestWriteTargetEntity:
                     torch.zeros(1, 7), env_ids=env_ids
                 )
 
-        with pytest.raises(ValueError, match="wrote 'root_pose' on both"):
-            self._trace(throw_both, {})
+        export = self._trace(throw_both, {})
+        assert [(w["kind"], w["entity"]) for w in export.write_targets] == [
+            ("root_pose", "ball"),
+            ("root_pose", "robot"),
+        ]
+        assert export.output_names == [
+            "ball__root_pose__pose",
+            "robot__root_pose__pose",
+        ]
+
+    def test_a_root_state_write_splits_into_pose_and_velocity(self):
+        """mjlab's own split of the 13-wide state, so a term using it traces as well as
+        one calling the two writes itself."""
+        torch = pytest.importorskip("torch")
+
+        def reset(env, env_ids):
+            env.scene["ball"].write_root_state_to_sim(
+                torch.zeros(1, 13), env_ids=env_ids
+            )
+
+        export = self._trace(reset, {})
+        assert [(w["kind"], w["entity"]) for w in export.write_targets] == [
+            ("root_pose", "ball"),
+            ("root_velocity", "ball"),
+        ]
+
+    def test_iterating_the_scene_never_touches_the_live_entities(self):
+        """A term walking `scene.entities` gets recording stand-ins: writing through the
+        live ones would move the tracing env under every term traced after it."""
+        torch = pytest.importorskip("torch")
+        env = self._env()
+
+        def reset_all(env, env_ids):
+            for entity in env.scene.entities.values():
+                entity.write_root_link_pose_to_sim(torch.zeros(1, 7), env_ids=env_ids)
+
+        export = self._trace(reset_all, {}, env=env)
+        assert {w["entity"] for w in export.write_targets} == {"robot", "ball"}
+        assert [e.written for e in env.scene.entities.values()] == [0, 0]
+
+    def test_an_uncaptured_write_is_refused_not_forwarded(self):
+        """Forwarding it would mutate the live env and emit no graph output for it."""
+        torch = pytest.importorskip("torch")
+
+        def spin(env, env_ids):
+            env.scene["robot"].write_root_link_velocity_b_to_sim(torch.zeros(1, 6))
+
+        with pytest.raises(ValueError, match="does not capture"):
+            self._trace(spin, {})
+
+
+def test_reset_scene_to_default_needs_no_graph():
+    """The runtime's own reset already restores every entity's default state, so mjlab's
+    default event has nothing left to write."""
+    from mjswan._onnx_build import _EVENTS_WITH_NOTHING_TO_WRITE
+
+    assert "reset_scene_to_default" in _EVENTS_WITH_NOTHING_TO_WRITE
 
 
 class TestApplyTerrainSpawn:

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -677,6 +677,96 @@ class TestFlatPatchSpawnTraces:
         )
 
 
+class TestWriteTargetEntity:
+    """Which entity a traced write lands on.
+
+    The browser resolves a root write through this name, and a scene with two floating
+    bodies — a robot and a thrown ball — has a free joint each. Reading the name off an
+    `asset_cfg` param only is what left it `null`: mjlab's own terms take that param, but
+    a task's term is free to take a plain `ball_name`, and then the write went to
+    whichever free joint came first in the model. The robot got launched; the ball never
+    moved.
+    """
+
+    @staticmethod
+    def _env():
+        torch = pytest.importorskip("torch")
+
+        class _Data:
+            def __init__(self):
+                self.root_link_pos_w = torch.zeros(1, 3)
+
+        class _Entity:
+            def __init__(self):
+                self.data = _Data()
+
+            def write_root_link_pose_to_sim(self, pose, env_ids=None): ...
+
+            def write_root_link_velocity_to_sim(self, velocity, env_ids=None): ...
+
+        class _Scene(dict):
+            def __getitem__(self, name):
+                return self.setdefault(name, _Entity())
+
+        class _Env:
+            def __init__(self):
+                self.scene = _Scene()
+                self.num_envs = 1
+                self.device = "cpu"
+
+        return _Env()
+
+    @staticmethod
+    def _trace(func, params):
+        pytest.importorskip("mjlab")
+        pytest.importorskip("torch")
+        from mjswan.compile import trace_event_term
+
+        return trace_event_term(
+            func, params, TestWriteTargetEntity._env(), name="throw", mode="interval"
+        )
+
+    def test_the_write_names_the_entity_it_was_made_on(self):
+        import torch
+
+        def throw(env, env_ids, ball_name="ball"):
+            ball = env.scene[ball_name]
+            ball.write_root_link_pose_to_sim(torch.zeros(1, 7), env_ids=env_ids)
+            ball.write_root_link_velocity_to_sim(torch.zeros(1, 6), env_ids=env_ids)
+
+        export = self._trace(throw, {"ball_name": "ball"})
+        assert [(w["kind"], w["entity"]) for w in export.write_targets] == [
+            ("root_pose", "ball"),
+            ("root_velocity", "ball"),
+        ]
+
+    def test_an_asset_cfg_still_names_it(self):
+        """mjlab's own convention keeps working, and stays the fallback."""
+        import torch
+        from mjlab.managers.scene_entity_config import SceneEntityCfg
+
+        def reset(env, env_ids, asset_cfg=None):
+            env.scene[asset_cfg.name].write_root_link_pose_to_sim(
+                torch.zeros(1, 7), env_ids=env_ids
+            )
+
+        export = self._trace(reset, {"asset_cfg": SceneEntityCfg("robot")})
+        assert [w["entity"] for w in export.write_targets] == ["robot"]
+
+    def test_two_entities_writing_one_kind_is_refused(self):
+        """One write per kind reaches the browser, so silently dropping one is worse."""
+        import torch
+
+        def throw_both(env, env_ids):
+            for name in ("ball", "robot"):
+                env.scene[name].write_root_link_pose_to_sim(
+                    torch.zeros(1, 7), env_ids=env_ids
+                )
+
+        with pytest.raises(ValueError, match="wrote 'root_pose' on both"):
+            self._trace(throw_both, {})
+
+
 class TestApplyTerrainSpawn:
     """`add_scene_mjlab` swaps mjlab's root-spawn reset once the terrain has patches."""
 


### PR DESCRIPTION
Three fidelity bugs, all found while building two
[mjswan_playground](https://github.com/ttktjmt/mjswan_playground) tasks around
[PAC-MAN](https://github.com/lzyang2000/perceptive_cbf_rl) — a G1 walk policy and its
perceptive dodgeball policy — from ordinary mjlab tasks. Two of them are silent; one fails
the build. (This PR now also carries what was #100, so the whole set is in one place.)

## 1. mjlab's dense observation history reached the runtime reversed

mjlab flattens a term's `CircularBuffer` **chronologically** — oldest frame first:

```python
>>> b = CircularBuffer(max_len=3, batch_size=1, device="cpu")
>>> for v in (1., 2., 3.): b.append(torch.tensor([[v]]))
>>> b.buffer.reshape(1, -1)
tensor([[1., 2., 3.]])
```

`HistoryObservation` expands a dense `history_length: n` into offsets `[0 … n-1]` — newest
first, as `HistoryObservation.test.ts` ("shifts frame-major, newest first") intends for
mjswan's own semantics. So every mjlab task carrying per-term or group history fed its
policy a correct-*width* observation with time running backwards.

The adapter now resolves an mjlab count into the explicit `history_steps` that reproduce
its order (`(n-1, …, 0)`), and drops the count from the adapted group so nothing applies it
twice. mjswan's own `history_length` keeps its newest-first meaning, so hand-written
configs (and `history_interleaved`, documented as Isaac-style) are untouched — see the open
question below.

Nothing existing could have caught it: the parity harness compares term *bodies*, and
history is orchestration around them.

## 2. A subclass of an mjlab config is still mjlab

`_is_from_mjlab` read the class's own `__module__`, so a task's **subclass** of
`ObservationGroupCfg` — how a project adds a field mjlab has no notion of (PAC-MAN
subclasses it to carry a `history_ordering` flag) — was not recognized, and
`adapt_observations` passed the group through unadapted. The mjlab *term* objects inside it
then reached the serializer:

```
AttributeError: 'ObservationTermCfg' object has no attribute 'history_steps'
  File "mjswan/_onnx_build.py", line 231, in _group_is_fusable
    if term_cfg.history_steps or _effective_history(group, term_cfg) > 1:
```

The CHANGELOG already records fixes of exactly this shape for the command and action
adapters ("maps a config wherever its class lives"); the observation and termination paths
still gated on the leaf class. Now the whole MRO is consulted.

## 3. An event's write landed on whatever free joint came first

The write target's entity came from an `asset_cfg` param:

```python
asset_cfg = params.get("asset_cfg")
entity = getattr(asset_cfg, "name", None)
```

mjlab's own terms carry that param, but a task's term need not — upstream's launcher is
`throw_ball_on_dwell(env, env_ids, ball_name="ball", robot_name="robot", …)` — so the
target serialized as `"entity": null`. The runtime treated the name as informational
("informational at N=1, single-entity scenes") and sent every root write to
`findFreeJoint(mjModel)`, the model's **first** free joint.

With a robot and a ball in one scene, that is the robot. Each throw teleported the G1 to
the launch point and gave it the ball's velocity — the robot flying across the floor on a
parabola every couple of seconds while the ball sat where the reset had parked it. Clean
build, correct graph, wrong body.

- **Python.** The recording proxies already know which entity a write was made on
  (`_EvRecEntity._name`), so `WriteCaptures` keeps that alongside the tensors and the write
  target takes the name from there. `asset_cfg` remains the fallback. Two entities writing
  the same kind in one term now raises — one write per kind reaches the browser, so keeping
  whichever came last was worse.
- **TypeScript.** `findEntityFreeJoint` resolves a named entity's own free joint through
  its body prefix (mjlab namespaces an entity's elements as `ball/…`), the same rule
  `entityJointIds` already applies to joints. It falls back to the first free joint for a
  single-entity scene, whose names carry no prefix, and for a model with no body names to
  read — the file's existing "degrade rather than throw" stance.

## Verification

- `pytest -m "not slow"`: 601 passed. `pytest -m slow` (incl. the parity sweep): 67 passed.
  `vitest run`: 366 passed. `tsc --noEmit` and `ruff` clean.
- New tests: dense mjlab history → `(2, 1, 0)`; a group-level count reaching every term
  with the group left countless; `history_length=1` staying unstacked; a subclassed mjlab
  group still adapted; a term naming its write target by a plain param serializing that
  entity; an `asset_cfg` term still doing so; two entities on one kind raising; and a
  two-entity model's write landing at the *ball's* qpos/qvel address with the robot's
  untouched.
- End to end on both PAC-MAN tasks, CPU: the walk bundle carries
  `history_offsets: [3, 2, 1, 0]` per term (384 = 96 × 4, the checkpoint's input),
  `run_parity` reports `max |Δ| = 0` over 32 steps, and in headless Chromium the policy
  walks upright for 24 s with no console errors. On the dodge task, the ball now flies at a
  stationary robot that dodges it, instead of the robot being launched.

## Open question (not in this PR)

Should mjswan's *own* `history_length` also mean oldest-first, matching mjlab outright?
That would make the two orders one rule, but it flips the layout for hand-written configs
and re-opens what `history_interleaved` (`[a0_t, a0_t-1, …]`) should be. Kept out of scope:
this PR only makes a traced mjlab task match mjlab.