### PR TITLE
Land an event's write on the entity it was made on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,15 @@ All kept as aliases via `_compat.py`, removed in 0.9:
   place — on the very object the task's live env config holds, leaving mjlab unable to
   resolve them when the tracing env was built, several frames from the cause. An
   unrecognized term is now copied rather than shared.
+- An event's write now lands on the entity it was made on. The write target's entity was
+  read off an `asset_cfg` param, which mjlab's own terms carry but a task's term need not
+  — a thrown ball's launcher takes a plain `ball_name` — so it serialized as `null`, and
+  the runtime then wrote every root pose to the model's *first* free joint. In a
+  two-entity scene (a robot and a ball) that launched the robot across the floor while
+  the ball never moved. The tracer records the entity from the write itself, `asset_cfg`
+  stays the fallback, and the runtime resolves a named entity's own free joint through
+  its body prefix. Two entities writing the same kind in one term is now an error rather
+  than a silent drop.
 - `run_parity` no longer feeds a graph inputs it does not declare, matching the runtime.
   A read the body only *indexes* with — a tracking command's `time_steps` — is recorded
   as a slot but folded in as a constant, so the export prunes it and ORT refused the

--- a/src/mjswan/compile/tracer.py
+++ b/src/mjswan/compile/tracer.py
@@ -725,19 +725,46 @@ _WRITE_FIELDS: dict[str, tuple[str, ...]] = {
 }
 
 
+class WriteCaptures(dict):
+    """``kind`` → written tensors, plus the entity each write was made on.
+
+    A term names its target however it likes — mjlab's own convention is an
+    ``asset_cfg`` param, but a task is free to take a plain ``ball_name`` — so the
+    entity is recorded from the write itself rather than guessed from the params.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.entities: dict[str, str] = {}
+
+
 class _WriteCaptureMixin:
     """Records ``write_*_to_sim`` calls into ``self._captures`` (kind → tensors)."""
+
+    def _capture(self, kind: str, values: tuple[Any, ...]) -> None:
+        self._captures[kind] = values
+        entities = getattr(self._captures, "entities", None)
+        name = getattr(self, "_name", None)
+        if entities is None or name is None:
+            return
+        previous = entities.get(kind)
+        if previous is not None and previous != name:
+            raise ValueError(
+                f"Term wrote {kind!r} on both {previous!r} and {name!r}; the browser "
+                "applies one write per kind, so it would land on one of them only."
+            )
+        entities[kind] = name
 
     def write_joint_state_to_sim(
         self, position, velocity, joint_ids=None, env_ids=None
     ):
-        self._captures["joint_state"] = (position, velocity)
+        self._capture("joint_state", (position, velocity))
 
     def write_root_link_pose_to_sim(self, pose, env_ids=None):
-        self._captures["root_pose"] = (pose,)
+        self._capture("root_pose", (pose,))
 
     def write_root_link_velocity_to_sim(self, velocity, env_ids=None):
-        self._captures["root_velocity"] = (velocity,)
+        self._capture("root_velocity", (velocity,))
 
 
 def _flatten_captures(
@@ -918,7 +945,7 @@ class _EventModule(nn.Module):
         served.update(_const_values(self, self._const_buffers))
         for (entity, field_name), tensor in zip(self._dynamic_keys, dynamic):
             served[("data", entity, field_name)] = tensor
-        captures: dict[str, tuple[torch.Tensor, ...]] = {}
+        captures = WriteCaptures()
         env = _EventReplayEnv(served, captures, real_env=self._real_env)
         with ReplayRng(self._func, rand):
             self._func(env, None, **self._params)
@@ -997,7 +1024,7 @@ def trace_event_term(
     """
     # 1. Discovery on the live env: record draws + reads + written values.
     log: list[tuple[TaggedKey, Any]] = []
-    captures: dict[str, tuple[torch.Tensor, ...]] = {}
+    captures = WriteCaptures()
     proxy = _EventCaptureEnv(env, log, captures)
     with DrawRecorder(func) as rec:
         func(proxy, None, **params)
@@ -1036,12 +1063,14 @@ def trace_event_term(
         opset=opset,
     )
 
+    # The write itself says which entity it landed on; `asset_cfg` is the fallback for a
+    # term whose write the proxies did not attribute.
     asset_cfg = params.get("asset_cfg")
-    entity = getattr(asset_cfg, "name", None)
+    fallback_entity = getattr(asset_cfg, "name", None)
     write_targets = [
         {
             "kind": kind,
-            "entity": entity,
+            "entity": captures.entities.get(kind, fallback_entity),
             "fields": list(_WRITE_FIELDS[kind]),
             **(
                 {"joint_ids": _static_ids(getattr(asset_cfg, "joint_ids", None))}

--- a/src/mjswan/template/src/core/event/__tests__/entityWrite.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/entityWrite.test.ts
@@ -8,7 +8,12 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { applyEntityWrite, applyEntityWrites, findFreeJoint } from '../entityWrite';
+import {
+  applyEntityWrite,
+  applyEntityWrites,
+  findEntityFreeJoint,
+  findFreeJoint,
+} from '../entityWrite';
 import type { WriteTarget } from '../entityWrite';
 
 type MjModel = import('mujoco').MjModel;
@@ -42,6 +47,46 @@ function fakeModel(nHinge: number, withFreeJoint = true): MjModel {
     jnt_dofadr: Int32Array.from(dofadr),
     names: new Uint8Array(0).buffer,
     name_jntadr: Int32Array.from(jntType.map(() => 0)),
+    _nq: q,
+    _nv: d,
+  } as unknown as MjModel;
+}
+
+/**
+ * A robot (free joint + `nHinge` hinges) followed by a free-floating ball, named as
+ * mjlab prefixes them: `robot/pelvis`, `ball/ball`.
+ */
+function fakeSceneModel(nHinge = 2): MjModel {
+  const jntType = [0, ...Array.from({ length: nHinge }, () => 3), 0];
+  const qposadr: number[] = [];
+  const dofadr: number[] = [];
+  let q = 0;
+  let d = 0;
+  for (const type of jntType) {
+    qposadr.push(q);
+    dofadr.push(d);
+    q += type === 0 ? 7 : 1;
+    d += type === 0 ? 6 : 1;
+  }
+  // One body per joint, plus the world body at index 0.
+  const bodyNames = ['world', 'robot/pelvis', ...Array.from({ length: nHinge }, (_, i) => `robot/link${i}`), 'ball/ball'];
+  const encoder = new TextEncoder();
+  const blob: number[] = [];
+  const bodyAdr: number[] = [];
+  for (const name of bodyNames) {
+    bodyAdr.push(blob.length);
+    blob.push(...encoder.encode(name), 0);
+  }
+  return {
+    njnt: jntType.length,
+    nbody: bodyNames.length,
+    jnt_type: Int32Array.from(jntType),
+    jnt_qposadr: Int32Array.from(qposadr),
+    jnt_dofadr: Int32Array.from(dofadr),
+    jnt_bodyid: Int32Array.from(jntType.map((_, j) => j + 1)),
+    names: Uint8Array.from(blob).buffer,
+    name_jntadr: Int32Array.from(jntType.map(() => 0)),
+    name_bodyadr: Int32Array.from(bodyAdr),
     _nq: q,
     _nv: d,
   } as unknown as MjModel;
@@ -206,5 +251,55 @@ describe('applyEntityWrites', () => {
     expect(applied).toBe(2);
     expect(data.qpos[0]).toBeCloseTo(0.4, 6);
     expect(data.qpos[3]).toBeCloseTo(1, 6);
+  });
+});
+
+describe('findEntityFreeJoint', () => {
+  it('finds the named entity\'s own free joint, not the first one', () => {
+    const model = fakeSceneModel();
+    expect(findEntityFreeJoint(model, 'robot')).toBe(0);
+    expect(findEntityFreeJoint(model, 'ball')).toBe(3);
+  });
+
+  it('falls back to the first free joint without a name, or with an unknown one', () => {
+    const model = fakeSceneModel();
+    expect(findEntityFreeJoint(model, null)).toBe(0);
+    expect(findEntityFreeJoint(model, 'nobody')).toBe(0);
+  });
+
+  it('falls back for a single-entity scene, whose names carry no prefix', () => {
+    expect(findEntityFreeJoint(fakeModel(2), 'robot')).toBe(0);
+  });
+});
+
+describe('applyEntityWrite: a second entity', () => {
+  // A thrown ball is the case: the event writes the ball's root, and landing it on the
+  // robot's instead launches the robot across the scene while the ball never moves.
+  it('writes the pose and velocity at the named entity\'s address', () => {
+    const model = fakeSceneModel();
+    const data = fakeData(model);
+    const applied = applyEntityWrites(
+      model,
+      data,
+      [
+        { kind: 'root_pose', entity: 'ball', fields: ['pose'] },
+        { kind: 'root_velocity', entity: 'ball', fields: ['velocity'] },
+      ],
+      {
+        root_pose__pose: new Float32Array([2, 0.5, 1.8, 1, 0, 0, 0]),
+        root_velocity__velocity: new Float32Array([-4, -1, 0, 0, 0, 0]),
+      },
+    );
+    expect(applied).toBe(2);
+    // The ball's free joint starts after the robot's 7 qpos + 2 hinges.
+    expect(Array.from(data.qpos.slice(9, 16))).toEqual(
+      [2, 0.5, 1.8, 1, 0, 0, 0].map(v => expect.closeTo(v, 6)),
+    );
+    expect(Array.from(data.qvel.slice(8, 14))).toEqual(
+      [-4, -1, 0, 0, 0, 0].map(v => expect.closeTo(v, 6)),
+    );
+    // The robot stayed where it was.
+    expect(Array.from(data.qpos.slice(0, 7))).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    expect(Array.from(data.qvel.slice(0, 6))).toEqual([0, 0, 0, 0, 0, 0]);
   });
 });

--- a/src/mjswan/template/src/core/event/entityWrite.ts
+++ b/src/mjswan/template/src/core/event/entityWrite.ts
@@ -12,7 +12,8 @@ export type WriteKind = 'joint_state' | 'root_pose' | 'root_velocity';
 
 export interface WriteTarget {
   kind: WriteKind;
-  /** Entity the write applies to (informational at N=1, single-entity scenes). */
+  /** Entity the write applies to. A scene with two of them (a robot and a thrown ball)
+   * has a free joint each, and the first one is not always the right one. */
   entity?: string | null;
   fields: string[];
   /** Resolved joint indices for `joint_state`; `"all"` means every joint. */
@@ -22,12 +23,12 @@ export interface WriteTarget {
 /** Graph outputs keyed by the tracer's `"<kind>__<field>"` naming. */
 export type WriteValues = Record<string, Float32Array | Float64Array | number[]>;
 
-export function decodeJointNames(mjModel: MjModel): string[] {
+function decodeNames(mjModel: MjModel, addresses: Int32Array, count: number): string[] {
   const bytes = new Uint8Array(mjModel.names);
   const decoder = new TextDecoder();
   const names: string[] = [];
-  for (let j = 0; j < mjModel.njnt; j++) {
-    const start = mjModel.name_jntadr[j];
+  for (let i = 0; i < count; i++) {
+    const start = addresses[i];
     let end = start;
     while (end < bytes.length && bytes[end] !== 0) end++;
     names.push(decoder.decode(bytes.subarray(start, end)));
@@ -35,11 +36,34 @@ export function decodeJointNames(mjModel: MjModel): string[] {
   return names;
 }
 
+export function decodeJointNames(mjModel: MjModel): string[] {
+  return decodeNames(mjModel, mjModel.name_jntadr, mjModel.njnt);
+}
+
 export function findFreeJoint(mjModel: MjModel): number {
   for (let j = 0; j < mjModel.njnt; j++) {
     if (mjModel.jnt_type[j] === 0) return j; // mjJNT_FREE
   }
   return -1;
+}
+
+/**
+ * The free joint carrying `entity`'s root, or the model's first one.
+ *
+ * mjlab prefixes an entity's elements with its name, so the owner of a free joint is the
+ * prefix on its body. Falling back to the first free joint covers the single-entity
+ * scene, whose names carry no prefix at all — the same rule `entityJointIds` follows —
+ * and a model that carries no body names to read.
+ */
+export function findEntityFreeJoint(mjModel: MjModel, entity?: string | null): number {
+  if (!entity || !mjModel.name_bodyadr || !mjModel.jnt_bodyid) return findFreeJoint(mjModel);
+  const bodies = decodeNames(mjModel, mjModel.name_bodyadr, mjModel.nbody);
+  for (let j = 0; j < mjModel.njnt; j++) {
+    if (mjModel.jnt_type[j] !== 0) continue; // mjJNT_FREE
+    const body = bodies[mjModel.jnt_bodyid[j]] ?? '';
+    if (body === entity || body.startsWith(`${entity}/`)) return j;
+  }
+  return findFreeJoint(mjModel);
 }
 
 /**
@@ -56,9 +80,9 @@ export function applyEntityWrite(
     case 'joint_state':
       return writeJointState(mjModel, mjData, target, values);
     case 'root_pose':
-      return writeRootPose(mjModel, mjData, values['root_pose__pose']);
+      return writeRootPose(mjModel, mjData, target, values['root_pose__pose']);
     case 'root_velocity':
-      return writeRootVelocity(mjModel, mjData, values['root_velocity__velocity']);
+      return writeRootVelocity(mjModel, mjData, target, values['root_velocity__velocity']);
     default:
       return false;
   }
@@ -128,10 +152,11 @@ function writeJointState(
 function writeRootPose(
   mjModel: MjModel,
   mjData: MjData,
+  target: WriteTarget,
   pose: WriteValues[string] | undefined,
 ): boolean {
   if (!pose || pose.length < 7) return false;
-  const j = findFreeJoint(mjModel);
+  const j = findEntityFreeJoint(mjModel, target.entity);
   if (j < 0) return false;
   const adr = mjModel.jnt_qposadr[j];
   for (let i = 0; i < 7; i++) mjData.qpos[adr + i] = pose[i];
@@ -141,10 +166,11 @@ function writeRootPose(
 function writeRootVelocity(
   mjModel: MjModel,
   mjData: MjData,
+  target: WriteTarget,
   velocity: WriteValues[string] | undefined,
 ): boolean {
   if (!velocity || velocity.length < 6) return false;
-  const j = findFreeJoint(mjModel);
+  const j = findEntityFreeJoint(mjModel, target.entity);
   if (j < 0) return false;
   const adr = mjModel.jnt_dofadr[j];
   for (let i = 0; i < 6; i++) mjData.qvel[adr + i] = velocity[i];

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -677,6 +677,96 @@ class TestFlatPatchSpawnTraces:
         )
 
 
+class TestWriteTargetEntity:
+    """Which entity a traced write lands on.
+
+    The browser resolves a root write through this name, and a scene with two floating
+    bodies — a robot and a thrown ball — has a free joint each. Reading the name off an
+    `asset_cfg` param only is what left it `null`: mjlab's own terms take that param, but
+    a task's term is free to take a plain `ball_name`, and then the write went to
+    whichever free joint came first in the model. The robot got launched; the ball never
+    moved.
+    """
+
+    @staticmethod
+    def _env():
+        torch = pytest.importorskip("torch")
+
+        class _Data:
+            def __init__(self):
+                self.root_link_pos_w = torch.zeros(1, 3)
+
+        class _Entity:
+            def __init__(self):
+                self.data = _Data()
+
+            def write_root_link_pose_to_sim(self, pose, env_ids=None): ...
+
+            def write_root_link_velocity_to_sim(self, velocity, env_ids=None): ...
+
+        class _Scene(dict):
+            def __getitem__(self, name):
+                return self.setdefault(name, _Entity())
+
+        class _Env:
+            def __init__(self):
+                self.scene = _Scene()
+                self.num_envs = 1
+                self.device = "cpu"
+
+        return _Env()
+
+    @staticmethod
+    def _trace(func, params):
+        pytest.importorskip("mjlab")
+        pytest.importorskip("torch")
+        from mjswan.compile import trace_event_term
+
+        return trace_event_term(
+            func, params, TestWriteTargetEntity._env(), name="throw", mode="interval"
+        )
+
+    def test_the_write_names_the_entity_it_was_made_on(self):
+        import torch
+
+        def throw(env, env_ids, ball_name="ball"):
+            ball = env.scene[ball_name]
+            ball.write_root_link_pose_to_sim(torch.zeros(1, 7), env_ids=env_ids)
+            ball.write_root_link_velocity_to_sim(torch.zeros(1, 6), env_ids=env_ids)
+
+        export = self._trace(throw, {"ball_name": "ball"})
+        assert [(w["kind"], w["entity"]) for w in export.write_targets] == [
+            ("root_pose", "ball"),
+            ("root_velocity", "ball"),
+        ]
+
+    def test_an_asset_cfg_still_names_it(self):
+        """mjlab's own convention keeps working, and stays the fallback."""
+        import torch
+        from mjlab.managers.scene_entity_config import SceneEntityCfg
+
+        def reset(env, env_ids, asset_cfg=None):
+            env.scene[asset_cfg.name].write_root_link_pose_to_sim(
+                torch.zeros(1, 7), env_ids=env_ids
+            )
+
+        export = self._trace(reset, {"asset_cfg": SceneEntityCfg("robot")})
+        assert [w["entity"] for w in export.write_targets] == ["robot"]
+
+    def test_two_entities_writing_one_kind_is_refused(self):
+        """One write per kind reaches the browser, so silently dropping one is worse."""
+        import torch
+
+        def throw_both(env, env_ids):
+            for name in ("ball", "robot"):
+                env.scene[name].write_root_link_pose_to_sim(
+                    torch.zeros(1, 7), env_ids=env_ids
+                )
+
+        with pytest.raises(ValueError, match="wrote 'root_pose' on both"):
+            self._trace(throw_both, {})
+
+
 class TestApplyTerrainSpawn:
     """`add_scene_mjlab` swaps mjlab's root-spawn reset once the terrain has patches."""
 


### PR DESCRIPTION
Found while building the dodgeball half of the
[PAC-MAN](https://github.com/lzyang2000/perceptive_cbf_rl) playground task, whose scene
holds two floating bodies: a G1 and a thrown ball.

## What happened

A traced event's write target took its entity from an `asset_cfg` param:

```python
asset_cfg = params.get("asset_cfg")
entity = getattr(asset_cfg, "name", None)
```

mjlab's own terms carry that param, but a task's term need not — upstream's launcher is
`throw_ball_on_dwell(env, env_ids, ball_name="ball", robot_name="robot", ...)` — so the
target serialized as `"entity": null`. The runtime treated the name as informational
("informational at N=1, single-entity scenes") and sent every root write to
`findFreeJoint(mjModel)`, the model's **first** free joint.

With a robot and a ball in one scene, that is the robot. So each throw teleported the
robot to the launch point and gave it the ball's velocity — the G1 flying across the floor
on a parabola every couple of seconds while the ball sat where the reset had parked it.
Nothing failed: the build was clean, the graph was right, the write just went to the wrong
body.

## The fix

- **Python.** The recording proxies already know which entity a write was made on
  (`_EvRecEntity._name`), so `WriteCaptures` keeps that alongside the tensors and the
  write target takes the name from there. `asset_cfg` remains the fallback for a write the
  proxies did not attribute. Two entities writing the same kind in one term now raises —
  one write per kind reaches the browser, so keeping whichever came last was worse.
- **TypeScript.** `findEntityFreeJoint` resolves a named entity's own free joint through
  its body prefix (mjlab namespaces an entity's elements as `ball/…`), the same rule
  `entityJointIds` already applies to joints. It falls back to the first free joint for a
  single-entity scene, whose names carry no prefix, and for a model with no body names to
  read — the file's existing "degrade rather than throw" stance.

## Verification

- `pytest -m "not slow"`: 598 passed. `vitest run`: 366 passed. `tsc --noEmit` and `ruff`
  clean.
- New tests: a term naming its target by a plain param serializes that entity; an
  `asset_cfg` term still does; two entities on one kind raises; and on the TS side, a
  two-entity model's write lands at the *ball's* qpos/qvel address with the robot's
  untouched.
- End to end on the PAC-MAN dodge task: before, the browser launched the robot; after, the
  ball flies at a stationary robot and the policy dodges it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4rAVemSmVFn8YuKtajtZG)_