### PR TITLE
Match mjlab on history order, entity writes, and the velocity command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,57 @@ All kept as aliases via `_compat.py`, removed in 0.9:
   place — on the very object the task's live env config holds, leaving mjlab unable to
   resolve them when the tracing env was built, several frames from the cause. An
   unrecognized term is now copied rather than shared.
+- The observation and termination adapters convert a config wherever its class lives,
+  as the command and action adapters now do. `_is_from_mjlab` read the class's own
+  module, so a task's *subclass* of an mjlab `ObservationGroupCfg` — how a project adds
+  a field mjlab has no notion of — passed through unadapted, carrying mjlab term objects
+  into the serializer, which failed on the first mjswan-only field it read
+  (`AttributeError: 'ObservationTermCfg' object has no attribute 'history_steps'`). The
+  whole MRO is consulted now, not the leaf class.
+- **`history_length` now stacks oldest frame first** — `[x_{t-n+1} … x_t]`, the order
+  mjlab's `CircularBuffer` flattens — where it counted back from the newest frame. Every
+  mjlab task carrying per-term or group history was handing its policy a correct-*width*
+  observation with time running backwards, and the two sides now mean one thing by a
+  count. **A hand-written config trained on the newest-first layout must name its offsets
+  to keep it:** `history_length=3` becomes `history_steps=(0, 1, 2)`. The bundled examples
+  are migrated; `history_steps` is unchanged and still takes precedence. Neither the
+  parity harness nor a build error could have caught the mismatch: parity compares term
+  bodies, and history is orchestration around them.
+- `PolicyRunner`'s group-level frame stack (the hand-authored `{components,
+  history_steps}` config shape) stacks oldest-first too, so one rule holds across both
+  history paths. `history_interleaved` follows the stack, so its layout is now
+  `[a0_{t-n+1}, …, a0_t, a1_…]`.
+- A group's `history_length` replaces its terms' whenever it is set — `0` included, which
+  switches history off for the group, as mjlab's `ObservationManager` does. An explicit
+  `0` used to read as "unset" and leave each term's own count standing.
+- An event's write now lands on the entity it was made on, and on each entity it was made
+  on. The write target's entity was read off an `asset_cfg` param, which mjlab's own terms
+  carry but a task's term need not — a thrown ball's launcher takes a plain `ball_name` —
+  so it serialized as `null`, and the runtime then wrote every root pose to the model's
+  *first* free joint. In a two-entity scene (a robot and a ball) that launched the robot
+  across the floor while the ball never moved. The tracer keys a capture by `(entity,
+  kind)`, as mjlab writes per entity, so one term may now write several; each target
+  names the graph outputs holding its values. `asset_cfg` stays the fallback for a write
+  the proxies could not attribute, and its `joint_ids` scope its own entity only.
+- The runtime resolves a named entity's free joint through its **joint** name prefix, the
+  same rule mjlab uses to resolve an entity's own addresses (and the one `entityJointIds`
+  already applied). A namespaced model with no such entity now writes nothing rather than
+  falling back to the first free joint — mjlab raises on the scene lookup, and the
+  fallback is how a thrown ball launches the robot. An unprefixed model is still a
+  single-entity scene, where the one free joint is the entity's.
+- A root velocity write rotates its angular half into the body frame, as mjlab's
+  `write_root_velocity` does. Both halves arrive world-frame, but a free joint's `qvel`
+  holds world-frame linear and *body*-frame angular velocity, so the value was spinning
+  the body about the wrong axis for any orientation but identity.
+- `write_root_state_to_sim` traces, split into the pose and velocity writes mjlab splits
+  it into, and a `write_*_to_sim` the tracer does *not* capture is refused instead of
+  forwarded — forwarding it mutated the live tracing env, leaving every term traced after
+  it reading a moved sim. A term walking `scene.entities` gets recording stand-ins for the
+  same reason.
+- mjlab's default `reset_scene_to_default` event no longer fails the build. It restores
+  every entity's default root and joint state, which is what the runtime's own reset
+  already does (`mj_resetData` to `qpos0`, or keyframe 0) before any `mode="reset"` event
+  runs, so it is emitted as a native no-op with that reason.
 - `run_parity` no longer feeds a graph inputs it does not declare, matching the runtime.
   A read the body only *indexes* with — a tracking command's `time_steps` — is recorded
   as a slot but folded in as a constant, so the export prunes it and ORT refused the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ shortcuts were removed outright (no alias) — see Removed.**
 - Debug visualisation for command terms, mirroring mjlab's `debug_vis` — arrows and
   markers are emitted as data by `default_viz()`, toggled via `engine.debugVis.set`,
   and on by default as in mjlab's viewer.
+- **`UniformVelocityCommandCfg` binds to a traced command term in mjswan itself**, so a
+  task built on mjlab's locomotion commands migrates with no registration of its own —
+  `add_scene_mjlab` picks it up from the task's `env_cfg` like any other term. The
+  binding used to live in `examples/mjlab/defaults/commands`, out of reach of any
+  project that is not this repo, which left them hand-writing `velocity_command()`
+  sliders that only look like the real term. The trace-friendly rewrite of the two
+  bodies mjswan cannot trace as written now lives in `mjswan.envs.mdp.commands`;
+  `velocity_command()` stays, for a manual control panel on a scene with no mjlab task.
 - `Builder.add_project_mjlab(task_id, ...)` — instance-method counterpart to the
   `Builder.from_mjlab` classmethod factory, for adding an mjlab task to a builder
   that already has other projects. `from_mjlab` now delegates to it.
@@ -137,6 +145,17 @@ All kept as aliases via `_compat.py`, removed in 0.9:
   into the serializer, which failed on the first mjswan-only field it read
   (`AttributeError: 'ObservationTermCfg' object has no attribute 'history_steps'`). The
   whole MRO is consulted now, not the leaf class.
+- The velocity command's trace-friendly rewrite carries the rest of what mjlab's
+  `UniformVelocityCommand` does: forward-only envs (`rel_forward_envs`, which mjlab's
+  own velocity tasks set to `0.2` and `play=True` does not clear, so one resample in
+  five differed), world-frame envs (`rel_world_envs`, and the `vel_command_w` state it
+  reads), and the `heading_command` gate — the rewrite used to track heading
+  unconditionally, where the cfg default is off. `init_velocity_prob` is refused with a
+  message rather than silently dropped: it writes the robot's root state during
+  resampling, gated on that same draw. The command parity harness cannot see any of
+  this — it traces the overridden term and compares the graph against that same term,
+  so it establishes "graph == override" and never "override == mjlab", which
+  `tests/test_velocity_command.py` now pins directly.
 - **`history_length` now stacks oldest frame first** — `[x_{t-n+1} … x_t]`, the order
   mjlab's `CircularBuffer` flattens — where it counted back from the newest frame. Every
   mjlab task carrying per-term or group history was handing its policy a correct-*width*

--- a/docs/docs/api/core.md
+++ b/docs/docs/api/core.md
@@ -727,6 +727,8 @@ mjswan.velocity_command(
 
 Build a standard `"velocity"` command group (three sliders: `lin_vel_x`, `lin_vel_y`, `ang_vel_z`). Pass it via `commands={"velocity": mjswan.velocity_command(...)}` to `add_policy()`.
 
+This is a manual control panel, not mjlab's `UniformVelocityCommand` — nothing resamples, and the command is whatever the slider says. A scene built on an mjlab task should pass `UniformVelocityCommandCfg` itself, which mjswan binds to a traced term and gives mjlab's own joystick (Enable + per-axis `Max` + `Zero`).
+
 ### register_command
 
 ```python
@@ -909,9 +911,9 @@ API-compatible with their mjlab counterparts, so an mjlab config assigns straigh
 | `params` | `dict` | `{}` | Forwarded at trace time. `SceneEntityCfg` patterns resolve to static indices baked into the graph. |
 | `scale` | `float \| tuple \| None` | `None` | Element-wise scale, applied after `clip`. |
 | `clip` | `tuple[float, float] \| None` | `None` | Applied before `scale`, matching mjlab's order. |
-| `history_length` | `int` | `0` | Frames to stack. `0` = current frame only. |
-| `history_steps` | `tuple[int, ...] \| None` | `None` | Sparse look-back offsets instead of every frame — `(0, 1, 2, 4, 8, 16)` reaches 17 frames back with 6 values. Takes precedence over `history_length`. |
-| `history_interleaved` | `bool` | `False` | Isaac-style joint-major layout instead of frame-major. |
+| `history_length` | `int` | `0` | Frames to stack, **oldest first** (`[x_{t-n+1} … x_t]`), as mjlab's history buffer flattens them. `0` = current frame only. |
+| `history_steps` | `tuple[int, ...] \| None` | `None` | Look-back offsets in the order the policy reads them, instead of a count — `(16, 8, 4, 2, 1, 0)` reaches 17 frames back with 6 values, and `(0, 1, 2)` is `history_length=3` reversed. Takes precedence over `history_length`. |
+| `history_interleaved` | `bool` | `False` | Isaac-style element-major layout instead of frame-major. |
 
 `noise`, `delay_*`, and `flatten_history_dim` are accepted for mjlab compatibility and
 ignored — there is no training in the browser.
@@ -921,7 +923,7 @@ ignored — there is no training in the browser.
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `terms` | `dict[str, ObservationTermCfg]` | `{}` | Concatenated in declaration order. |
-| `history_length` | `int \| None` | `None` | Group-level override applied to every term. |
+| `history_length` | `int \| None` | `None` | Group-level override applied to every term whenever it is set — `0` included, which switches the group's history off, as in mjlab. |
 
 `concatenate_terms`, `enable_corruption`, and `flatten_history_dim` are accepted and
 ignored.

--- a/docs/docs/guides/policy-config.md
+++ b/docs/docs/guides/policy-config.md
@@ -108,9 +108,9 @@ obs = ObservationGroupCfg(
 | `params` | Forwarded to the function at trace time. Regex patterns in a `SceneEntityCfg` resolve to static indices and bake into the graph. |
 | `scale` | Element-wise scale, applied after `clip` (mjlab's order). |
 | `clip` | `(min, max)`, applied before `scale`. |
-| `history_length` | Number of past frames to stack. `0` = current frame only. |
-| `history_steps` | Sparse look-back offsets to stack instead of every frame — `(0, 1, 2, 4, 8, 16)` reaches 17 frames back while contributing only 6. Takes precedence over `history_length`. |
-| `history_interleaved` | Isaac-style joint-major layout (`[a0_t, a0_t-1, …, a1_t, …]`) instead of frame-major. |
+| `history_length` | Past frames to stack, **oldest first** (`[x_{t-n+1} … x_t]`), as mjlab's history buffer flattens them. `0` = current frame only. |
+| `history_steps` | Look-back offsets to stack, in the order the policy reads them, instead of a count — `(16, 8, 4, 2, 1, 0)` reaches 17 frames back at a width of 6, and `(0, 1, 2)` is `history_length=3` reversed. Takes precedence over `history_length`. |
+| `history_interleaved` | Isaac-style element-major layout (`[a0_{t-n+1}, …, a0_t, a1_…]`) instead of frame-major. |
 
 Other mjlab fields (`noise`, `delay_*`, `enable_corruption`, `nan_policy`) are accepted
 for config compatibility and ignored — there is no training in the browser.

--- a/examples/demo/gentle_humanoid/main.py
+++ b/examples/demo/gentle_humanoid/main.py
@@ -342,8 +342,7 @@ def setup_builder() -> mjswan.Builder:
                     params={"asset_cfg": policy_joints},
                     history_steps=tuple(tracking_cfg["joint_vel_history_steps"]),
                 ),
-                # The runtime already holds `last_action`, so only the stacking is ours
-                # — newest first, like the offsets the checkpoint names above.
+                # Newest-first, like the offsets above; the runtime holds `last_action`.
                 "prev_actions": ObservationTermCfg(
                     func=obs_fns.last_action,
                     history_steps=tuple(range(int(tracking_cfg["prev_action_steps"]))),

--- a/examples/demo/gentle_humanoid/main.py
+++ b/examples/demo/gentle_humanoid/main.py
@@ -342,10 +342,11 @@ def setup_builder() -> mjswan.Builder:
                     params={"asset_cfg": policy_joints},
                     history_steps=tuple(tracking_cfg["joint_vel_history_steps"]),
                 ),
-                # The runtime already holds `last_action`, so only the stacking is ours.
+                # The runtime already holds `last_action`, so only the stacking is ours
+                # — newest first, like the offsets the checkpoint names above.
                 "prev_actions": ObservationTermCfg(
                     func=obs_fns.last_action,
-                    history_length=int(tracking_cfg["prev_action_steps"]),
+                    history_steps=tuple(range(int(tracking_cfg["prev_action_steps"]))),
                 ),
             }
         ),

--- a/examples/demo/main.py
+++ b/examples/demo/main.py
@@ -46,8 +46,7 @@ from mjswan.trace_env import build_single_entity_trace_env  # noqa: E402
 # own trace env via SceneHandle.set_trace_env, and the terms below are written against
 # the same live-env API mjlab's own use. ---
 
-#: Three frames, newest first. `history_length` stacks chronologically (mjlab's order);
-#: these Go2 checkpoints were trained on the reverse, so they name the offsets.
+#: Newest first: these Go2 checkpoints predate `history_length` stacking chronologically.
 GO2_HISTORY_STEPS = (0, 1, 2)
 
 

--- a/examples/demo/main.py
+++ b/examples/demo/main.py
@@ -46,6 +46,10 @@ from mjswan.trace_env import build_single_entity_trace_env  # noqa: E402
 # own trace env via SceneHandle.set_trace_env, and the terms below are written against
 # the same live-env API mjlab's own use. ---
 
+#: Three frames, newest first. `history_length` stacks chronologically (mjlab's order);
+#: these Go2 checkpoints were trained on the reverse, so they name the offsets.
+GO2_HISTORY_STEPS = (0, 1, 2)
+
 
 def joint_pos_abs(env, *, asset_cfg: SceneEntityCfg = SceneEntityCfg(name="robot")):
     """Absolute joint positions (no default-pose subtraction)."""
@@ -242,17 +246,17 @@ def _add_go2_scene(project) -> None:
         "policy": ObservationGroupCfg(
             terms={
                 "projected_gravity": ObservationTermCfg(
-                    func=obs_fns.projected_gravity, history_length=3
+                    func=obs_fns.projected_gravity, history_steps=GO2_HISTORY_STEPS
                 ),
                 "joint_pos": ObservationTermCfg(
-                    func=obs_fns.joint_pos_rel, history_length=3
+                    func=obs_fns.joint_pos_rel, history_steps=GO2_HISTORY_STEPS
                 ),
                 "joint_vel": ObservationTermCfg(
-                    func=obs_fns.joint_vel_rel, history_length=3
+                    func=obs_fns.joint_vel_rel, history_steps=GO2_HISTORY_STEPS
                 ),
                 "prev_actions": ObservationTermCfg(
                     func=obs_fns.last_action,
-                    history_length=3,
+                    history_steps=GO2_HISTORY_STEPS,
                     history_interleaved=True,
                 ),
             }
@@ -279,17 +283,17 @@ def _add_go2_scene(project) -> None:
             "policy": ObservationGroupCfg(
                 terms={
                     "projected_gravity": ObservationTermCfg(
-                        func=obs_fns.projected_gravity, history_length=3
+                        func=obs_fns.projected_gravity, history_steps=GO2_HISTORY_STEPS
                     ),
                     "joint_pos": ObservationTermCfg(
-                        func=joint_pos_abs, history_length=3
+                        func=joint_pos_abs, history_steps=GO2_HISTORY_STEPS
                     ),
                     "joint_vel": ObservationTermCfg(
-                        func=obs_fns.joint_vel_rel, history_length=3
+                        func=obs_fns.joint_vel_rel, history_steps=GO2_HISTORY_STEPS
                     ),
                     "prev_actions": ObservationTermCfg(
                         func=obs_fns.last_action,
-                        history_length=3,
+                        history_steps=GO2_HISTORY_STEPS,
                         history_interleaved=True,
                     ),
                 }

--- a/examples/mjlab/defaults/commands/__init__.py
+++ b/examples/mjlab/defaults/commands/__init__.py
@@ -1,14 +1,13 @@
 """Mjlab-specific command registrations for mjswan examples. Import before
 ``builder.build()``.
 
-``LiftingCommandCfg`` and ``UniformVelocityCommandCfg`` are traced to ONNX and run by
-the shared ``OnnxCommand`` handler. ``MotionCommandCfg`` stays native, with only its
-reset jitter traced.
+``LiftingCommandCfg`` is traced to ONNX and run by the shared ``OnnxCommand`` handler.
+``MotionCommandCfg`` stays native, with only its reset jitter traced.
+``UniformVelocityCommandCfg`` needs nothing here — mjswan itself binds it.
 """
 
 from __future__ import annotations
 
-import types
 from typing import Any
 
 import torch
@@ -17,7 +16,6 @@ from mjlab.utils.lab_api.math import (
     quat_from_euler_xyz,
     quat_mul,
     sample_uniform,
-    wrap_to_pi,
 )
 
 from mjswan import CommandBinding, register_command
@@ -33,64 +31,6 @@ register_command(
     CommandBinding(
         state_fields=["target_pos"],
         command_field="target_pos",
-    ),
-)
-
-
-# --- UniformVelocityCommand (velocity tasks) needs a trace-friendly override: the real
-# `_resample_command` uses RNG the spy cannot see and `_update_command` branches on data.
-# The override is equivalent at N=1, via `sample_uniform` and `torch.where`. ---
-
-
-def _tf_resample_command(self: Any, env_ids: torch.Tensor) -> None:
-    n = self.num_envs
-    dev = self.device
-    r = self.cfg.ranges
-    vx = sample_uniform(r.lin_vel_x[0], r.lin_vel_x[1], (n, 1), device=dev)
-    vy = sample_uniform(r.lin_vel_y[0], r.lin_vel_y[1], (n, 1), device=dev)
-    wz = sample_uniform(r.ang_vel_z[0], r.ang_vel_z[1], (n, 1), device=dev)
-    self.vel_command_b = torch.cat([vx, vy, wz], dim=-1)
-    self.heading_target = sample_uniform(r.heading[0], r.heading[1], (n,), device=dev)
-    is_heading = sample_uniform(0.0, 1.0, (n,), device=dev)
-    self.is_heading_env = is_heading <= self.cfg.rel_heading_envs
-    standing = sample_uniform(0.0, 1.0, (n,), device=dev)
-    self.is_standing_env = standing <= self.cfg.rel_standing_envs
-
-
-def _tf_update_command(self: Any) -> None:
-    heading_err = wrap_to_pi(self.heading_target - self.robot.data.heading_w)
-    wz = torch.clip(
-        self.cfg.heading_control_stiffness * heading_err,
-        min=self.cfg.ranges.ang_vel_z[0],
-        max=self.cfg.ranges.ang_vel_z[1],
-    ).reshape(-1, 1)
-    heading_mask = self.is_heading_env.reshape(-1, 1)
-    vx = self.vel_command_b[:, 0:1]
-    vy = self.vel_command_b[:, 1:2]
-    wz_col = torch.where(heading_mask, wz, self.vel_command_b[:, 2:3])
-    vc = torch.cat([vx, vy, wz_col], dim=-1)
-    standing = self.is_standing_env.reshape(-1, 1)
-    self.vel_command_b = torch.where(standing, torch.zeros_like(vc), vc)
-
-
-def _bind_trace_friendly_velocity_override(term: Any) -> None:
-    term._resample_command = types.MethodType(_tf_resample_command, term)
-    term._update_command = types.MethodType(_tf_update_command, term)
-
-
-# No `ui=`: the joystick descriptor is recorded from `create_gui` at build time
-# (`mjswan.adapters.gui_spy`).
-register_command(
-    "UniformVelocityCommandCfg",
-    CommandBinding(
-        state_fields=[
-            "vel_command_b",
-            "heading_target",
-            "is_heading_env",
-            "is_standing_env",
-        ],
-        command_field="vel_command_b",
-        trace_override=_bind_trace_friendly_velocity_override,
     ),
 )
 

--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -131,9 +131,11 @@ def _apply_observation_pipeline(
         )
     if term_cfg.clip is not None:
         entry["clip"] = list(term_cfg.clip)
+    # A group count replaces the term's whenever it is set, `0` included, as mjlab's
+    # own `ObservationManager` does.
     history = (
         group_history_length
-        if (group_history_length or 0) > 0
+        if group_history_length is not None
         else term_cfg.history_length
     )
     if term_cfg.history_steps:
@@ -213,7 +215,9 @@ def _effective_history(group: ObservationGroupCfg, term_cfg: ObservationTermCfg)
     """
     if term_cfg.history_steps:
         return len(term_cfg.history_steps)
-    return int(group.history_length or term_cfg.history_length or 0)
+    if group.history_length is not None:
+        return int(group.history_length)
+    return int(term_cfg.history_length or 0)
 
 
 def _group_is_fusable(group: ObservationGroupCfg) -> bool:
@@ -784,6 +788,11 @@ _EVENTS_WITH_NOTHING_TO_WRITE: dict[str, str] = {
     "encoder_bias": (
         "it writes `Entity.data.encoder_bias`, which the runtime applies from the policy "
         "config's `encoder_bias` rather than from an event graph"
+    ),
+    "reset_scene_to_default": (
+        "it restores every entity's default root and joint state, which is what the "
+        "runtime's own reset already does (`mj_resetData` to `qpos0`, or keyframe 0) "
+        'before any `mode="reset"` event runs'
     ),
 }
 

--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -131,8 +131,7 @@ def _apply_observation_pipeline(
         )
     if term_cfg.clip is not None:
         entry["clip"] = list(term_cfg.clip)
-    # A group count replaces the term's whenever it is set, `0` included, as mjlab's
-    # own `ObservationManager` does.
+    # A group count replaces the term's whenever set, `0` included, as mjlab does.
     history = (
         group_history_length
         if group_history_length is not None

--- a/src/mjswan/adapters/mjlab_adapter.py
+++ b/src/mjswan/adapters/mjlab_adapter.py
@@ -4,9 +4,9 @@ mjlab is a **soft dependency** — this module never fails at import time.
 When mjlab is not installed the ``adapt_*`` functions simply return their
 inputs unchanged (they are assumed to already be mjswan types).
 
-The adapter detects mjlab types by checking the module path of the class
-(``type(obj).__module__``) rather than ``isinstance``, so mjlab does not
-need to be importable for mjswan to function.
+The adapter detects mjlab types by the module path of any class in the MRO
+rather than ``isinstance``, so mjlab does not need to be importable for
+mjswan to function.
 
 Mapping strategy
 ----------------
@@ -58,9 +58,15 @@ from ..managers.termination_manager import (
 
 
 def _is_from_mjlab(obj: Any) -> bool:
-    """Check whether *obj*'s class originates from the ``mjlab`` package."""
-    module = getattr(type(obj), "__module__", "") or ""
-    return module.startswith("mjlab")
+    """Check whether *obj*'s class derives from the ``mjlab`` package.
+
+    The whole MRO, not just the leaf: a task subclassing an mjlab config to add a
+    field of its own reports its *own* module.
+    """
+    return any(
+        (getattr(klass, "__module__", "") or "").startswith("mjlab")
+        for klass in type(obj).__mro__
+    )
 
 
 # --- Observation adaptation ---

--- a/src/mjswan/adapters/mjlab_adapter.py
+++ b/src/mjswan/adapters/mjlab_adapter.py
@@ -58,11 +58,8 @@ from ..managers.termination_manager import (
 
 
 def _is_from_mjlab(obj: Any) -> bool:
-    """Check whether *obj*'s class derives from the ``mjlab`` package.
-
-    The whole MRO, not just the leaf: a task subclassing an mjlab config to add a
-    field of its own reports its *own* module.
-    """
+    """Whether any class in *obj*'s MRO comes from ``mjlab``: a task's subclass of an
+    mjlab config reports its own module, so the leaf class alone is not enough."""
     return any(
         (getattr(klass, "__module__", "") or "").startswith("mjlab")
         for klass in type(obj).__mro__

--- a/src/mjswan/command.py
+++ b/src/mjswan/command.py
@@ -274,7 +274,12 @@ def velocity_command(
     default_lin_vel_y: float = 0.0,
     default_ang_vel_z: float = 0.0,
 ) -> CommandTermConfig:
-    """Create a built-in UI command term for planar velocity control."""
+    """Three sliders the operator drives, as a ``ui_command`` preset.
+
+    Not mjlab's ``UniformVelocityCommand``: nothing resamples, and the value is
+    whatever the slider says. A scene carrying an mjlab task should pass that cfg
+    instead (``mjswan.envs.mdp.commands`` binds it) and get mjlab's own joystick.
+    """
 
     return ui_command(
         [

--- a/src/mjswan/compile/parity.py
+++ b/src/mjswan/compile/parity.py
@@ -16,6 +16,7 @@ import torch
 from .rng import DrawRecorder
 from .tracer import (
     TermExport,
+    WriteCaptures,
     _EventCaptureEnv,
     _flatten_captures,
     read_slot,
@@ -247,7 +248,7 @@ def run_parity(
             )
             for _ in range(n_event_draws):
                 # Record a fresh reference invocation (real draws, no sim write).
-                captures: dict[str, tuple] = {}
+                captures: WriteCaptures = {}
                 proxy = _EventCaptureEnv(env, [], captures)
                 with DrawRecorder(func) as rec:
                     func(proxy, None, **params)

--- a/src/mjswan/compile/tracer.py
+++ b/src/mjswan/compile/tracer.py
@@ -725,23 +725,57 @@ _WRITE_FIELDS: dict[str, tuple[str, ...]] = {
 }
 
 
+#: A write is keyed by the entity it was made on as well as its kind: one term may
+#: write several entities — mjlab's own `reset_scene_to_default` writes every entity
+#: in the scene — and each needs its own outputs and its own target.
+WriteKey = tuple[str | None, str]
+WriteCaptures = dict[WriteKey, tuple[torch.Tensor, ...]]
+
+
+def _write_output_name(key: WriteKey, field_name: str) -> str:
+    """Graph-output name for one written tensor.
+
+    Unprefixed when the write carries no entity, which is what a single-entity command
+    term records.
+    """
+    entity, kind = key
+    return f"{entity}__{kind}__{field_name}" if entity else f"{kind}__{field_name}"
+
+
 class _WriteCaptureMixin:
-    """Records ``write_*_to_sim`` calls into ``self._captures`` (kind → tensors)."""
+    """Records ``write_*_to_sim`` calls into ``self._captures``.
+
+    A term names its target however it likes — mjlab's own convention is an
+    ``asset_cfg`` param, but a task is free to take a plain ``ball_name`` — so the
+    entity comes from the write itself rather than from the params.
+    """
+
+    #: Entity this proxy stands for; None for a command term whose cfg names none.
+    _name: str | None
+    _captures: WriteCaptures
+
+    def _capture(self, kind: str, values: tuple[Any, ...]) -> None:
+        self._captures[(self._name, kind)] = values
 
     def write_joint_state_to_sim(
         self, position, velocity, joint_ids=None, env_ids=None
     ):
-        self._captures["joint_state"] = (position, velocity)
+        self._capture("joint_state", (position, velocity))
 
     def write_root_link_pose_to_sim(self, pose, env_ids=None):
-        self._captures["root_pose"] = (pose,)
+        self._capture("root_pose", (pose,))
 
     def write_root_link_velocity_to_sim(self, velocity, env_ids=None):
-        self._captures["root_velocity"] = (velocity,)
+        self._capture("root_velocity", (velocity,))
+
+    def write_root_state_to_sim(self, root_state, env_ids=None):
+        # mjlab's own split of a 13-wide root state into the two writes above.
+        self._capture("root_pose", (root_state[..., :7],))
+        self._capture("root_velocity", (root_state[..., 7:],))
 
 
 def _flatten_captures(
-    captures: dict[str, tuple[torch.Tensor, ...]],
+    captures: WriteCaptures,
 ) -> tuple[list[str], list[torch.Tensor]]:
     """Flatten a captures dict into (output_names, tensors).
 
@@ -750,9 +784,9 @@ def _flatten_captures(
     """
     names: list[str] = []
     tensors: list[torch.Tensor] = []
-    for kind, values in captures.items():
-        for field_name, tensor in zip(_WRITE_FIELDS[kind], values):
-            names.append(f"{kind}__{field_name}")
+    for key, values in captures.items():
+        for field_name, tensor in zip(_WRITE_FIELDS[key[1]], values):
+            names.append(_write_output_name(key, field_name))
             tensors.append(tensor)
     return names, tensors
 
@@ -782,6 +816,13 @@ class _EvRecEntity(_WriteCaptureMixin):
         object.__setattr__(self, "_captures", captures)
 
     def __getattr__(self, name: str) -> Any:
+        if name.startswith("write_") and name.endswith("_to_sim"):
+            # Forwarding it would mutate the live env mid-trace and capture nothing.
+            raise ValueError(
+                f"Term called {name}() on entity {self._name!r}, which the tracer does "
+                "not capture. Add it to `_WriteCaptureMixin` and `_WRITE_FIELDS` with a "
+                "runtime counterpart, or hand the term to the browser as a TS class."
+            )
         value = getattr(self._real, name)
         # Only tensors and control-flow scalars can be reproduced during replay.
         if isinstance(value, (torch.Tensor, bool, int, float)):
@@ -809,6 +850,14 @@ class _EvRecScene:
         return _EvRecEntity(self._real[name], name, self._log, self._captures)
 
     def __getattr__(self, name: str) -> Any:
+        if name == "entities":
+            # Recording stand-ins, not the live entities: a term that iterates the
+            # scene (mjlab's `reset_scene_to_default`) would otherwise write straight
+            # into the tracing env, leaving every later term traced against a moved sim.
+            return {
+                key: _EvRecEntity(real, key, self._log, self._captures)
+                for key, real in self._real.entities.items()
+            }
         value = getattr(self._real, name)
         if isinstance(value, (torch.Tensor, bool, int, float)):
             self._log.append((("scene", name), value))
@@ -858,14 +907,22 @@ class _EvReplayEntity(_WriteCaptureMixin):
 
 
 class _EvReplayScene:
-    def __init__(self, served, captures):
+    def __init__(self, served, captures, real_env: Any):
         self._served = served
         self._captures = captures
+        self._real_env = real_env
 
     def __getitem__(self, name: str) -> _EvReplayEntity:
         return _EvReplayEntity(name, self._served, self._captures)
 
     def __getattr__(self, name: str) -> Any:
+        if name == "entities":
+            # Which entities the scene holds is static structure, so it comes from the
+            # real env, as `num_envs` does — only their tensors are recorded slots.
+            return {
+                key: _EvReplayEntity(key, self._served, self._captures)
+                for key in self._real_env.scene.entities
+            }
         try:
             return self._served[("scene", name)]
         except KeyError:
@@ -876,7 +933,7 @@ class _EvReplayScene:
 
 class _EventReplayEnv:
     def __init__(self, served, captures, *, real_env: Any):
-        self.scene = _EvReplayScene(served, captures)
+        self.scene = _EvReplayScene(served, captures, real_env)
         self._real_env = real_env
 
     def __getattr__(self, name: str) -> Any:
@@ -918,7 +975,7 @@ class _EventModule(nn.Module):
         served.update(_const_values(self, self._const_buffers))
         for (entity, field_name), tensor in zip(self._dynamic_keys, dynamic):
             served[("data", entity, field_name)] = tensor
-        captures: dict[str, tuple[torch.Tensor, ...]] = {}
+        captures: WriteCaptures = {}
         env = _EventReplayEnv(served, captures, real_env=self._real_env)
         with ReplayRng(self._func, rand):
             self._func(env, None, **self._params)
@@ -997,16 +1054,16 @@ def trace_event_term(
     """
     # 1. Discovery on the live env: record draws + reads + written values.
     log: list[tuple[TaggedKey, Any]] = []
-    captures: dict[str, tuple[torch.Tensor, ...]] = {}
+    captures: WriteCaptures = {}
     proxy = _EventCaptureEnv(env, log, captures)
     with DrawRecorder(func) as rec:
         func(proxy, None, **params)
 
     if not captures:
         raise ValueError(
-            f"Event term {name!r} wrote nothing traceable "
-            "(no write_joint_state/root_pose/root_velocity_to_sim call); handle "
-            "it natively or extend _WRITE_FIELDS."
+            f"Event term {name!r} wrote nothing traceable (no write_joint_state / "
+            "write_root_state / write_root_link_pose / write_root_link_velocity call); "
+            "handle it natively or extend _WRITE_FIELDS."
         )
     output_names, ref_tensors = _flatten_captures(captures)
     ref_rand = rec.rand_vector
@@ -1036,21 +1093,25 @@ def trace_event_term(
         opset=opset,
     )
 
+    # The write itself says which entity it landed on; `asset_cfg` is the fallback for a
+    # term whose write the proxies did not attribute.
     asset_cfg = params.get("asset_cfg")
-    entity = getattr(asset_cfg, "name", None)
-    write_targets = [
-        {
+    asset_name = getattr(asset_cfg, "name", None)
+    write_targets = []
+    for key in captures:
+        entity, kind = key
+        target: dict[str, Any] = {
             "kind": kind,
-            "entity": entity,
+            "entity": entity or asset_name,
             "fields": list(_WRITE_FIELDS[kind]),
-            **(
-                {"joint_ids": _static_ids(getattr(asset_cfg, "joint_ids", None))}
-                if kind == "joint_state"
-                else {}
-            ),
+            "outputs": [_write_output_name(key, f) for f in _WRITE_FIELDS[kind]],
         }
-        for kind in captures
-    ]
+        # `asset_cfg`'s ids scope its own entity; any other one gets all of its joints.
+        joint_ids = _static_ids(getattr(asset_cfg, "joint_ids", None))
+        scoped = entity is None or entity == asset_name
+        if kind == "joint_state" and scoped and joint_ids is not None:
+            target["joint_ids"] = joint_ids
+        write_targets.append(target)
 
     return EventExport(
         name=name,
@@ -1113,7 +1174,7 @@ class _RecordCommand:
         self._attrs = entity_attr_names
         self._entity_name = entity_name
         self.log: list[tuple[TaggedKey, Any]] = []
-        self.captures: dict[str, tuple[torch.Tensor, ...]] = {}
+        self.captures: WriteCaptures = {}
 
     def __enter__(self) -> _RecordCommand:
         self._orig = {a: getattr(self.term, a) for a in self._attrs}
@@ -1205,7 +1266,7 @@ class _CommandModule(nn.Module):
         for (entity, field_name), tensor in zip(self._dynamic_keys, dynamic):
             served[("data", entity, field_name)] = tensor
 
-        captures: dict[str, tuple[torch.Tensor, ...]] = {}
+        captures: WriteCaptures = {}
         orig = {a: getattr(self._term, a) for a in self._entity_attr_names}
         orig_env = getattr(self._term, "_env", None)
         for a in self._entity_attr_names:
@@ -1296,8 +1357,15 @@ def trace_command_term(
 
     output_write_names, _ = _flatten_captures(captures)
     write_targets = [
-        {"kind": kind, "entity": entity_name, "fields": list(_WRITE_FIELDS[kind])}
-        for kind in captures
+        {
+            "kind": kind,
+            "entity": entity or entity_name,
+            "fields": list(_WRITE_FIELDS[kind]),
+            "outputs": [
+                _write_output_name((entity, kind), f) for f in _WRITE_FIELDS[kind]
+            ],
+        }
+        for entity, kind in captures
     ]
 
     # 2. Classify reads: dynamic data inputs vs baked tensor/scalar constants.

--- a/src/mjswan/compile/tracer.py
+++ b/src/mjswan/compile/tracer.py
@@ -725,19 +725,14 @@ _WRITE_FIELDS: dict[str, tuple[str, ...]] = {
 }
 
 
-#: A write is keyed by the entity it was made on as well as its kind: one term may
-#: write several entities — mjlab's own `reset_scene_to_default` writes every entity
-#: in the scene — and each needs its own outputs and its own target.
+#: Keyed by entity as well as kind: one term may write several entities (mjlab's
+#: `reset_scene_to_default` writes them all), each needing its own target and outputs.
 WriteKey = tuple[str | None, str]
 WriteCaptures = dict[WriteKey, tuple[torch.Tensor, ...]]
 
 
 def _write_output_name(key: WriteKey, field_name: str) -> str:
-    """Graph-output name for one written tensor.
-
-    Unprefixed when the write carries no entity, which is what a single-entity command
-    term records.
-    """
+    """Graph-output name for one written tensor; unprefixed when no entity was named."""
     entity, kind = key
     return f"{entity}__{kind}__{field_name}" if entity else f"{kind}__{field_name}"
 
@@ -745,12 +740,11 @@ def _write_output_name(key: WriteKey, field_name: str) -> str:
 class _WriteCaptureMixin:
     """Records ``write_*_to_sim`` calls into ``self._captures``.
 
-    A term names its target however it likes — mjlab's own convention is an
-    ``asset_cfg`` param, but a task is free to take a plain ``ball_name`` — so the
-    entity comes from the write itself rather than from the params.
+    The entity comes from the write itself, not the params: a term names its target
+    however it likes (``asset_cfg``, or a plain ``ball_name``).
     """
 
-    #: Entity this proxy stands for; None for a command term whose cfg names none.
+    #: Entity this proxy stands for; None when the cfg names none.
     _name: str | None
     _captures: WriteCaptures
 
@@ -851,9 +845,8 @@ class _EvRecScene:
 
     def __getattr__(self, name: str) -> Any:
         if name == "entities":
-            # Recording stand-ins, not the live entities: a term that iterates the
-            # scene (mjlab's `reset_scene_to_default`) would otherwise write straight
-            # into the tracing env, leaving every later term traced against a moved sim.
+            # Stand-ins, not the live entities: a term iterating the scene would
+            # otherwise write into the tracing env, moving the sim under later terms.
             return {
                 key: _EvRecEntity(real, key, self._log, self._captures)
                 for key, real in self._real.entities.items()
@@ -917,8 +910,8 @@ class _EvReplayScene:
 
     def __getattr__(self, name: str) -> Any:
         if name == "entities":
-            # Which entities the scene holds is static structure, so it comes from the
-            # real env, as `num_envs` does — only their tensors are recorded slots.
+            # Static structure, so it comes from the real env, as `num_envs` does —
+            # only the entities' tensors are recorded slots.
             return {
                 key: _EvReplayEntity(key, self._served, self._captures)
                 for key in self._real_env.scene.entities
@@ -1093,8 +1086,7 @@ def trace_event_term(
         opset=opset,
     )
 
-    # The write itself says which entity it landed on; `asset_cfg` is the fallback for a
-    # term whose write the proxies did not attribute.
+    # The write says which entity it landed on; `asset_cfg` is the fallback.
     asset_cfg = params.get("asset_cfg")
     asset_name = getattr(asset_cfg, "name", None)
     write_targets = []

--- a/src/mjswan/envs/mdp/__init__.py
+++ b/src/mjswan/envs/mdp/__init__.py
@@ -11,9 +11,8 @@ none of mjlab's term functions. Pass mjlab's own straight to
 ``ObservationTermCfg(func=obs_fns.base_lin_vel)`` and the build traces them. These
 submodules carry only the ``*Binding`` escape hatch and its ``register_*`` registry.
 
-``commands`` is the one exception. A command is a class rather than a function, and
-some of mjlab's use constructs the tracer cannot follow, so it carries trace-friendly
-rewrites of those bodies — imported here for the registrations they perform.
+``commands`` is the exception: a command is a class, and some of mjlab's use constructs
+the tracer cannot follow, so it carries trace-friendly rewrites of those bodies.
 """
 
 from . import actions, commands, observations, terminations

--- a/src/mjswan/envs/mdp/__init__.py
+++ b/src/mjswan/envs/mdp/__init__.py
@@ -10,9 +10,13 @@ real, directly-usable action-term configs, same import pattern as mjlab::
 none of mjlab's term functions. Pass mjlab's own straight to
 ``ObservationTermCfg(func=obs_fns.base_lin_vel)`` and the build traces them. These
 submodules carry only the ``*Binding`` escape hatch and its ``register_*`` registry.
+
+``commands`` is the one exception. A command is a class rather than a function, and
+some of mjlab's use constructs the tracer cannot follow, so it carries trace-friendly
+rewrites of those bodies — imported here for the registrations they perform.
 """
 
-from . import actions, observations, terminations
+from . import actions, commands, observations, terminations
 from .events import EventBinding
 from .observations import ObservationBinding
 from .terminations import TerminationBinding
@@ -26,6 +30,7 @@ __all__ = [
     "ObservationBinding",
     "TerminationBinding",
     "actions",
+    "commands",
     "observations",
     "terminations",
 ]

--- a/src/mjswan/envs/mdp/commands.py
+++ b/src/mjswan/envs/mdp/commands.py
@@ -1,0 +1,160 @@
+"""Trace-friendly rewrites of mjlab command bodies, and their registrations.
+
+The other ``envs/mdp`` submodules reimplement nothing: a task's own function object is
+traced as-is. A *command* is a class, not a function, and two of mjlab's use constructs
+the tracer cannot follow — ``Tensor.uniform_`` draws its RNG spy cannot see, and
+per-``env_ids`` index assignment that branches on live data. ``CommandBinding``'s
+``trace_override`` exists for exactly this: the term is rebound to a body that is
+equivalent at ``N=1`` and expressible as one graph, then traced.
+
+A rewrite is a second copy of mjlab's math, so it has to be read against the original
+whenever mjlab moves. ``tests/test_velocity_command.py`` pins the two bodies against a
+live mjlab term, which the command parity harness cannot do: it traces the *overridden*
+term and compares the graph against that same term, so it only ever checks
+"graph == override", never "override == mjlab".
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+from ...command import CommandBinding, register_command
+
+try:
+    # Module-level, not deferred: the tracer's RNG spy patches a term body's *module
+    # globals*, so `sample_uniform` has to be one of ours to be seen at all.
+    import torch
+    from mjlab.utils.lab_api.math import sample_uniform, wrap_to_pi
+except ImportError:
+    pass
+
+
+# --- UniformVelocityCommand (mjlab's locomotion tasks, and anything built on them) ---
+
+#: `UniformVelocityCommand`'s floor on a forward-only env's commanded speed.
+_FORWARD_MIN_SPEED = 0.3
+
+#: Cfg fields whose behaviour the rewrite below does not carry, and what each does.
+#: Reaching one is a build error rather than a silent difference in the browser.
+_UNMODELLED_FIELDS: tuple[tuple[str, str], ...] = (
+    (
+        "init_velocity_prob",
+        "starts an episode at the commanded velocity by writing the robot's root "
+        "state during resampling, which needs a write gated on that same draw",
+    ),
+)
+
+
+def _resample_velocity_command(self: Any, env_ids: Any) -> None:
+    """``UniformVelocityCommand._resample_command``, as one graph at ``N=1``.
+
+    mjlab assigns through ``env_ids`` and draws with ``Tensor.uniform_``; this draws
+    with ``sample_uniform`` and selects with ``torch.where``, in mjlab's own order:
+    the world-frame reference is the raw sample, copied *before* the forward clamp.
+    """
+    cfg = self.cfg
+    ranges = cfg.ranges
+    n, device = self.num_envs, self.device
+
+    vx = sample_uniform(*ranges.lin_vel_x, (n, 1), device=device)
+    vy = sample_uniform(*ranges.lin_vel_y, (n, 1), device=device)
+    wz = sample_uniform(*ranges.ang_vel_z, (n, 1), device=device)
+    if cfg.heading_command:
+        self.heading_target = sample_uniform(*ranges.heading, (n,), device=device)
+        self.is_heading_env = (
+            sample_uniform(0.0, 1.0, (n,), device=device) <= cfg.rel_heading_envs
+        )
+    self.is_standing_env = (
+        sample_uniform(0.0, 1.0, (n,), device=device) <= cfg.rel_standing_envs
+    )
+    self.is_world_env = (
+        sample_uniform(0.0, 1.0, (n,), device=device) <= cfg.rel_world_envs
+    )
+    self.vel_command_w = torch.cat([vx, vy, wz], dim=-1)
+
+    self.is_forward_env = (
+        sample_uniform(0.0, 1.0, (n,), device=device) <= cfg.rel_forward_envs
+    )
+    forward = self.is_forward_env.reshape(-1, 1)
+    zero = torch.zeros_like(vx)
+    vx = torch.where(forward, vx.abs().clamp(min=_FORWARD_MIN_SPEED), vx)
+    self.vel_command_b = torch.cat(
+        [vx, torch.where(forward, zero, vy), torch.where(forward, zero, wz)], dim=-1
+    )
+
+
+def _update_velocity_command(self: Any) -> None:
+    """``UniformVelocityCommand._update_command``, as one graph at ``N=1``.
+
+    Heading-tracking envs re-derive yaw from the heading error every step, world-frame
+    envs rotate their stored reference into the body frame, and standing envs are
+    zeroed last — the order mjlab applies them in.
+    """
+    cfg = self.cfg
+    heading_w = self.robot.data.heading_w
+    vx = self.vel_command_b[:, 0:1]
+    vy = self.vel_command_b[:, 1:2]
+    wz = self.vel_command_b[:, 2:3]
+
+    if cfg.heading_command:
+        tracked = torch.clip(
+            cfg.heading_control_stiffness * wrap_to_pi(self.heading_target - heading_w),
+            min=cfg.ranges.ang_vel_z[0],
+            max=cfg.ranges.ang_vel_z[1],
+        ).reshape(-1, 1)
+        wz = torch.where(self.is_heading_env.reshape(-1, 1), tracked, wz)
+
+    world = self.is_world_env.reshape(-1, 1)
+    cos_h = torch.cos(heading_w).reshape(-1, 1)
+    sin_h = torch.sin(heading_w).reshape(-1, 1)
+    vx_w = self.vel_command_w[:, 0:1]
+    vy_w = self.vel_command_w[:, 1:2]
+    vx = torch.where(world, cos_h * vx_w + sin_h * vy_w, vx)
+    vy = torch.where(world, -sin_h * vx_w + cos_h * vy_w, vy)
+
+    standing = self.is_standing_env.reshape(-1, 1)
+    command = torch.cat([vx, vy, wz], dim=-1)
+    self.vel_command_b = torch.where(standing, torch.zeros_like(command), command)
+    self.vel_command_w = torch.where(
+        standing, torch.zeros_like(self.vel_command_w), self.vel_command_w
+    )
+
+
+def bind_velocity_override(term: Any) -> None:
+    """Swap a built ``UniformVelocityCommand`` onto the two bodies above."""
+    for field, behaviour in _UNMODELLED_FIELDS:
+        if float(getattr(term.cfg, field, 0.0) or 0.0) > 0.0:
+            raise ValueError(
+                f"UniformVelocityCommandCfg sets {field}="
+                f"{getattr(term.cfg, field)!r}, which mjswan's trace-friendly "
+                f"rewrite does not carry: it {behaviour}. Tracing it anyway would "
+                "give the browser a command that differs from mjlab's, so extend "
+                "`mjswan.envs.mdp.commands` or register your own override via "
+                "mjswan.register_command('UniformVelocityCommandCfg', ...)."
+            )
+    term._resample_command = types.MethodType(_resample_velocity_command, term)
+    term._update_command = types.MethodType(_update_velocity_command, term)
+
+
+# No `ui=`: the joystick descriptor is recorded from the term's own `create_gui` at
+# build time (`mjswan.adapters.gui_spy`). No `viz=`: `command.default_viz` has it.
+register_command(
+    "UniformVelocityCommandCfg",
+    CommandBinding(
+        state_fields=[
+            "vel_command_b",
+            "vel_command_w",
+            "heading_target",
+            "is_heading_env",
+            "is_standing_env",
+            "is_world_env",
+            "is_forward_env",
+        ],
+        command_field="vel_command_b",
+        trace_override=bind_velocity_override,
+    ),
+)
+
+
+__all__ = ["bind_velocity_override"]

--- a/src/mjswan/envs/mdp/commands.py
+++ b/src/mjswan/envs/mdp/commands.py
@@ -1,17 +1,13 @@
 """Trace-friendly rewrites of mjlab command bodies, and their registrations.
 
-The other ``envs/mdp`` submodules reimplement nothing: a task's own function object is
-traced as-is. A *command* is a class, not a function, and two of mjlab's use constructs
-the tracer cannot follow — ``Tensor.uniform_`` draws its RNG spy cannot see, and
-per-``env_ids`` index assignment that branches on live data. ``CommandBinding``'s
-``trace_override`` exists for exactly this: the term is rebound to a body that is
-equivalent at ``N=1`` and expressible as one graph, then traced.
+A command is a class, not a function, and mjlab's use constructs the tracer cannot
+follow: ``Tensor.uniform_`` draws its RNG spy cannot see, and per-``env_ids`` assignment
+that branches on live data. ``CommandBinding.trace_override`` rebinds the term to a body
+equivalent at ``N=1`` and expressible as one graph.
 
-A rewrite is a second copy of mjlab's math, so it has to be read against the original
-whenever mjlab moves. ``tests/test_velocity_command.py`` pins the two bodies against a
-live mjlab term, which the command parity harness cannot do: it traces the *overridden*
-term and compares the graph against that same term, so it only ever checks
-"graph == override", never "override == mjlab".
+Each rewrite is a second copy of mjlab's math, so it has to be reread whenever mjlab
+moves. ``tests/test_velocity_command.py`` pins it against a live mjlab term, which the
+parity harness cannot: that only ever checks "graph == override".
 """
 
 from __future__ import annotations
@@ -22,8 +18,8 @@ from typing import Any
 from ...command import CommandBinding, register_command
 
 try:
-    # Module-level, not deferred: the tracer's RNG spy patches a term body's *module
-    # globals*, so `sample_uniform` has to be one of ours to be seen at all.
+    # Module-level, not deferred: the RNG spy patches a term body's *module globals*,
+    # so `sample_uniform` has to be one of ours to be seen.
     import torch
     from mjlab.utils.lab_api.math import sample_uniform, wrap_to_pi
 except ImportError:
@@ -35,8 +31,7 @@ except ImportError:
 #: `UniformVelocityCommand`'s floor on a forward-only env's commanded speed.
 _FORWARD_MIN_SPEED = 0.3
 
-#: Cfg fields whose behaviour the rewrite below does not carry, and what each does.
-#: Reaching one is a build error rather than a silent difference in the browser.
+#: Cfg fields the rewrite does not carry: a build error, not a silent difference.
 _UNMODELLED_FIELDS: tuple[tuple[str, str], ...] = (
     (
         "init_velocity_prob",
@@ -49,9 +44,8 @@ _UNMODELLED_FIELDS: tuple[tuple[str, str], ...] = (
 def _resample_velocity_command(self: Any, env_ids: Any) -> None:
     """``UniformVelocityCommand._resample_command``, as one graph at ``N=1``.
 
-    mjlab assigns through ``env_ids`` and draws with ``Tensor.uniform_``; this draws
-    with ``sample_uniform`` and selects with ``torch.where``, in mjlab's own order:
-    the world-frame reference is the raw sample, copied *before* the forward clamp.
+    In mjlab's own order: the world-frame reference is the raw sample, copied *before*
+    the forward clamp.
     """
     cfg = self.cfg
     ranges = cfg.ranges
@@ -87,9 +81,8 @@ def _resample_velocity_command(self: Any, env_ids: Any) -> None:
 def _update_velocity_command(self: Any) -> None:
     """``UniformVelocityCommand._update_command``, as one graph at ``N=1``.
 
-    Heading-tracking envs re-derive yaw from the heading error every step, world-frame
-    envs rotate their stored reference into the body frame, and standing envs are
-    zeroed last — the order mjlab applies them in.
+    Heading tracking, then the world-frame rotation, then standing zeroed last — the
+    order mjlab applies them in.
     """
     cfg = self.cfg
     heading_w = self.robot.data.heading_w

--- a/src/mjswan/managers/observation_manager.py
+++ b/src/mjswan/managers/observation_manager.py
@@ -70,23 +70,19 @@ class ObservationTermCfg:
     """(min, max) clipping range applied after scaling."""
 
     history_length: int = 0
-    """Number of past frames to stack, oldest first — ``[x_{t-n+1} … x_t]``, as
-    mjlab's chronological history buffer flattens them. 0 = current only."""
+    """Past frames to stack, oldest first (``[x_{t-n+1} … x_t]``), as mjlab's history
+    buffer flattens them. 0 = current only."""
 
     history_steps: tuple[int, ...] | None = None
     """Look-back offsets to stack, in the order the policy reads them, instead of a
-    count of frames.
-
-    Two things a count cannot say. A *sparse* window — e.g. ``(16, 8, 4, 2, 1, 0)`` —
-    reaches 17 frames back while contributing only 6, keeping the term's width at
-    ``len(history_steps)`` where ``history_length`` would give 17. And a different
-    *order*: ``(0, 1, 2, 3)`` stacks four frames newest-first, the reverse of
-    ``history_length=4``. Takes precedence over ``history_length`` when both are set."""
+    count. Says two things a count cannot: a *sparse* window — ``(16, 8, 4, 2, 1, 0)``
+    reaches 17 frames back at a width of 6, where ``history_length`` would give 17 — and
+    a different *order*, ``(0, 1, 2, 3)`` being ``history_length=4`` reversed. Takes
+    precedence over ``history_length`` when both are set."""
 
     history_interleaved: bool = False
-    """Isaac-style element-major history layout: ``[a0_{t-n+1}, …, a0_t, a1_…]``
-    instead of frame-major (``[x_{t-n+1}, …, x_t]``, each the full vector). Only
-    meaningful when history is stacked at all."""
+    """Isaac-style element-major layout — ``[a0_{t-n+1}, …, a0_t, a1_…]`` instead of
+    frame-major ``[x_{t-n+1}, …, x_t]``. Only meaningful alongside history."""
 
     flatten_history_dim: bool = True
     """Whether to flatten history into the feature dimension.

--- a/src/mjswan/managers/observation_manager.py
+++ b/src/mjswan/managers/observation_manager.py
@@ -70,21 +70,23 @@ class ObservationTermCfg:
     """(min, max) clipping range applied after scaling."""
 
     history_length: int = 0
-    """Number of past frames to stack. 0 = current only (no history)."""
+    """Number of past frames to stack, oldest first — ``[x_{t-n+1} … x_t]``, as
+    mjlab's chronological history buffer flattens them. 0 = current only."""
 
     history_steps: tuple[int, ...] | None = None
-    """Sparse look-back offsets to stack, instead of every frame.
+    """Look-back offsets to stack, in the order the policy reads them, instead of a
+    count of frames.
 
-    mjlab only counts frames (``history_length=n`` → offsets ``0..n-1``), but a
-    policy can be trained on a *sparse* window — e.g. ``(0, 1, 2, 4, 8, 16)``, which
-    reaches 17 frames back while contributing only 6. Naming the offsets keeps the
-    term's width at ``len(history_steps)`` frames; ``history_length`` would give 17.
-    Takes precedence over ``history_length`` when both are set."""
+    Two things a count cannot say. A *sparse* window — e.g. ``(16, 8, 4, 2, 1, 0)`` —
+    reaches 17 frames back while contributing only 6, keeping the term's width at
+    ``len(history_steps)`` where ``history_length`` would give 17. And a different
+    *order*: ``(0, 1, 2, 3)`` stacks four frames newest-first, the reverse of
+    ``history_length=4``. Takes precedence over ``history_length`` when both are set."""
 
     history_interleaved: bool = False
-    """Isaac-style joint-major history layout: ``[a0_t, a0_t-1, ..., a1_t, ...]``
-    instead of frame-major (``[a_t, a_t-1, ...]`` each the full vector). Only
-    meaningful when ``history_length`` > 0."""
+    """Isaac-style element-major history layout: ``[a0_{t-n+1}, …, a0_t, a1_…]``
+    instead of frame-major (``[x_{t-n+1}, …, x_t]``, each the full vector). Only
+    meaningful when history is stacked at all."""
 
     flatten_history_dim: bool = True
     """Whether to flatten history into the feature dimension.
@@ -153,7 +155,8 @@ class ObservationGroupCfg:
     """Accepted for mjlab compatibility; ignored (no training in browser)."""
 
     history_length: int | None = None
-    """Group-level history override. If set, applies to all terms."""
+    """Group-level history override. If not None, replaces every term's own count —
+    ``0`` included, which switches history off for the group, as in mjlab."""
 
     flatten_history_dim: bool = True
     """Accepted for mjlab compatibility; mjswan always flattens."""

--- a/src/mjswan/template/src/core/event/__tests__/entityWrite.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/entityWrite.test.ts
@@ -2,13 +2,20 @@
  * `entity_write` apply primitive (ADR 0005 §3).
  *
  * Take a value an ONNX graph already computed and write it into mjData — the
- * graph owns the sampling, so this side only applies. The write kinds and the
- * `"<kind>__<field>"` output naming mirror the Python tracer's `_WRITE_FIELDS`, so
- * these tests double as the contract between the two sides.
+ * graph owns the sampling, so this side only applies. The write kinds, the output
+ * naming (`"<entity>__<kind>__<field>"`, or `"<kind>__<field>"` from a bundle built
+ * before a term could write two entities) and the world-frame velocity convention
+ * mirror the Python tracer's `_WRITE_FIELDS`, so these tests double as the contract
+ * between the two sides.
  */
 import { describe, expect, it } from 'vitest';
 
-import { applyEntityWrite, applyEntityWrites, findFreeJoint } from '../entityWrite';
+import {
+  applyEntityWrite,
+  applyEntityWrites,
+  findEntityFreeJoint,
+  findFreeJoint,
+} from '../entityWrite';
 import type { WriteTarget } from '../entityWrite';
 
 type MjModel = import('mujoco').MjModel;
@@ -42,6 +49,47 @@ function fakeModel(nHinge: number, withFreeJoint = true): MjModel {
     jnt_dofadr: Int32Array.from(dofadr),
     names: new Uint8Array(0).buffer,
     name_jntadr: Int32Array.from(jntType.map(() => 0)),
+    _nq: q,
+    _nv: d,
+  } as unknown as MjModel;
+}
+
+/**
+ * A robot (free joint + `nHinge` hinges) followed by a free-floating ball, with joints
+ * named as mjlab namespaces them — `robot/…`, `ball/…` — which is how it resolves an
+ * entity's own addresses.
+ */
+function fakeSceneModel(nHinge = 2): MjModel {
+  const jntType = [0, ...Array.from({ length: nHinge }, () => 3), 0];
+  const jntNames = [
+    'robot/floating_base_joint',
+    ...Array.from({ length: nHinge }, (_, i) => `robot/joint${i}`),
+    'ball/floating_base_joint',
+  ];
+  const qposadr: number[] = [];
+  const dofadr: number[] = [];
+  let q = 0;
+  let d = 0;
+  for (const type of jntType) {
+    qposadr.push(q);
+    dofadr.push(d);
+    q += type === 0 ? 7 : 1;
+    d += type === 0 ? 6 : 1;
+  }
+  const encoder = new TextEncoder();
+  const blob: number[] = [];
+  const jntAdr: number[] = [];
+  for (const name of jntNames) {
+    jntAdr.push(blob.length);
+    blob.push(...encoder.encode(name), 0);
+  }
+  return {
+    njnt: jntType.length,
+    jnt_type: Int32Array.from(jntType),
+    jnt_qposadr: Int32Array.from(qposadr),
+    jnt_dofadr: Int32Array.from(dofadr),
+    names: Uint8Array.from(blob).buffer,
+    name_jntadr: Int32Array.from(jntAdr),
     _nq: q,
     _nv: d,
   } as unknown as MjModel;
@@ -158,6 +206,7 @@ describe('applyEntityWrite: root pose / velocity', () => {
   it('writes the 6-vector velocity into the free joint qvel', () => {
     const model = fakeModel(1);
     const data = fakeData(model);
+    data.qpos.set([0, 0, 0, 1, 0, 0, 0], 0); // identity orientation
     const vel = new Float32Array([0.1, 0.2, 0.3, -0.1, -0.2, -0.3]);
     expect(
       applyEntityWrite(model, data, { kind: 'root_velocity', fields: ['velocity'] }, {
@@ -165,6 +214,45 @@ describe('applyEntityWrite: root pose / velocity', () => {
       }),
     ).toBe(true);
     for (let i = 0; i < 6; i++) expect(data.qvel[i]).toBeCloseTo(vel[i], 6);
+  });
+
+  it('rotates the angular half into the body frame, as mjlab does', () => {
+    // A free joint's qvel is world-frame linear + *body*-frame angular, but the term
+    // wrote both in the world frame. Skipping the rotation spins the body about the
+    // wrong axis for any orientation but identity.
+    const model = fakeModel(1);
+    const data = fakeData(model);
+    // 90 degrees about +z: (w, x, y, z) = (cos45, 0, 0, sin45).
+    const h = Math.SQRT1_2;
+    data.qpos.set([0, 0, 0, h, 0, 0, h], 0);
+    applyEntityWrite(model, data, { kind: 'root_velocity', fields: ['velocity'] }, {
+      root_velocity__velocity: new Float32Array([1, 0, 0, 2, 0, 0]),
+    });
+    // Linear stays world-frame; world +x angular reads as body -y after the inverse.
+    expect(Array.from(data.qvel.slice(0, 3))).toEqual([1, 0, 0].map(v => expect.closeTo(v, 6)));
+    expect(Array.from(data.qvel.slice(3, 6))).toEqual([0, -2, 0].map(v => expect.closeTo(v, 6)));
+  });
+
+  it('reads the orientation a pose written first left behind', () => {
+    // `write_root_state_to_sim` splits into pose then velocity, and mjlab reads the
+    // quaternion out of qpos — so the new pose is the frame, not the old one.
+    const model = fakeModel(1);
+    const data = fakeData(model);
+    const h = Math.SQRT1_2;
+    const applied = applyEntityWrites(
+      model,
+      data,
+      [
+        { kind: 'root_pose', entity: 'robot', fields: ['pose'] },
+        { kind: 'root_velocity', entity: 'robot', fields: ['velocity'] },
+      ],
+      {
+        root_pose__pose: new Float32Array([0, 0, 1, h, 0, 0, h]),
+        root_velocity__velocity: new Float32Array([0, 0, 0, 2, 0, 0]),
+      },
+    );
+    expect(applied).toBe(2);
+    expect(Array.from(data.qvel.slice(3, 6))).toEqual([0, -2, 0].map(v => expect.closeTo(v, 6)));
   });
 
   it('degrades (returns false) on a fixed-base model instead of throwing', () => {
@@ -206,5 +294,92 @@ describe('applyEntityWrites', () => {
     expect(applied).toBe(2);
     expect(data.qpos[0]).toBeCloseTo(0.4, 6);
     expect(data.qpos[3]).toBeCloseTo(1, 6);
+  });
+});
+
+describe('findEntityFreeJoint', () => {
+  it('finds the named entity\'s own free joint, not the first one', () => {
+    const model = fakeSceneModel();
+    expect(findEntityFreeJoint(model, 'robot')).toBe(0);
+    expect(findEntityFreeJoint(model, 'ball')).toBe(3);
+  });
+
+  it('takes the first free joint when no entity is named', () => {
+    expect(findEntityFreeJoint(fakeSceneModel(), null)).toBe(0);
+  });
+
+  it('owns nothing in a namespaced model that has no such entity', () => {
+    // Landing on the first free joint instead is how a thrown ball launches the robot,
+    // and mjlab would not get this far: `env.scene["nobody"]` raises.
+    expect(findEntityFreeJoint(fakeSceneModel(), 'nobody')).toBe(-1);
+  });
+
+  it('takes the one free joint of an unprefixed, single-entity scene', () => {
+    expect(findEntityFreeJoint(fakeModel(2), 'robot')).toBe(0);
+  });
+});
+
+describe('applyEntityWrite: entity-prefixed outputs', () => {
+  it('reads each target\'s value through the outputs it declares', () => {
+    // Two entities, one kind: the values only tell them apart by name.
+    const model = fakeSceneModel();
+    const data = fakeData(model);
+    const applied = applyEntityWrites(
+      model,
+      data,
+      [
+        {
+          kind: 'root_pose',
+          entity: 'robot',
+          fields: ['pose'],
+          outputs: ['robot__root_pose__pose'],
+        },
+        {
+          kind: 'root_pose',
+          entity: 'ball',
+          fields: ['pose'],
+          outputs: ['ball__root_pose__pose'],
+        },
+      ],
+      {
+        robot__root_pose__pose: new Float32Array([0, 0, 0.8, 1, 0, 0, 0]),
+        ball__root_pose__pose: new Float32Array([2, 0.5, 1.8, 1, 0, 0, 0]),
+      },
+    );
+    expect(applied).toBe(2);
+    expect(data.qpos[2]).toBeCloseTo(0.8, 6);
+    expect(data.qpos[9]).toBeCloseTo(2, 6);
+  });
+});
+
+describe('applyEntityWrite: a second entity', () => {
+  // A thrown ball is the case: the event writes the ball's root, and landing it on the
+  // robot's instead launches the robot across the scene while the ball never moves.
+  it('writes the pose and velocity at the named entity\'s address', () => {
+    const model = fakeSceneModel();
+    const data = fakeData(model);
+    const applied = applyEntityWrites(
+      model,
+      data,
+      [
+        { kind: 'root_pose', entity: 'ball', fields: ['pose'] },
+        { kind: 'root_velocity', entity: 'ball', fields: ['velocity'] },
+      ],
+      {
+        root_pose__pose: new Float32Array([2, 0.5, 1.8, 1, 0, 0, 0]),
+        root_velocity__velocity: new Float32Array([-4, -1, 0, 0, 0, 0]),
+      },
+    );
+    expect(applied).toBe(2);
+    // The ball's free joint starts after the robot's 7 qpos + 2 hinges.
+    expect(Array.from(data.qpos.slice(9, 16))).toEqual(
+      [2, 0.5, 1.8, 1, 0, 0, 0].map(v => expect.closeTo(v, 6)),
+    );
+    expect(Array.from(data.qvel.slice(8, 14))).toEqual(
+      [-4, -1, 0, 0, 0, 0].map(v => expect.closeTo(v, 6)),
+    );
+    // The robot stayed where it was.
+    expect(Array.from(data.qpos.slice(0, 7))).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    expect(Array.from(data.qvel.slice(0, 6))).toEqual([0, 0, 0, 0, 0, 0]);
   });
 });

--- a/src/mjswan/template/src/core/event/entityWrite.ts
+++ b/src/mjswan/template/src/core/event/entityWrite.ts
@@ -12,14 +12,18 @@ export type WriteKind = 'joint_state' | 'root_pose' | 'root_velocity';
 
 export interface WriteTarget {
   kind: WriteKind;
-  /** Entity the write applies to (informational at N=1, single-entity scenes). */
+  /** Entity the write applies to. One term may write several — mjlab resolves each
+   * entity's own addresses — and the model's first free joint is not always the one. */
   entity?: string | null;
   fields: string[];
-  /** Resolved joint indices for `joint_state`; `"all"` means every joint. */
-  joint_ids?: number[] | 'all';
+  /** Graph outputs holding `fields`, in the same order. Absent in bundles built before
+   * a term could write two entities, whose outputs are named `"<kind>__<field>"`. */
+  outputs?: string[];
+  /** Resolved joint indices for `joint_state`; `"all"` (or absent) means every joint. */
+  joint_ids?: number[] | 'all' | null;
 }
 
-/** Graph outputs keyed by the tracer's `"<kind>__<field>"` naming. */
+/** Graph outputs, keyed as `WriteTarget.outputs` names them. */
 export type WriteValues = Record<string, Float32Array | Float64Array | number[]>;
 
 export function decodeJointNames(mjModel: MjModel): string[] {
@@ -43,6 +47,60 @@ export function findFreeJoint(mjModel: MjModel): number {
 }
 
 /**
+ * Which of `entity`'s joints a write reaches, by mjlab's rule: it resolves an entity's
+ * addresses from that entity's own spec joints, whose names it namespaces `entity/…`.
+ *
+ * An unprefixed model is a single-entity scene, where every joint is the entity's — the
+ * hand-built scenes mjswan also serves. A *prefixed* model with no such entity owns
+ * nothing the write belongs to, so it gets nothing: mjlab would raise on the scene
+ * lookup, and landing on another entity is how a thrown ball launches the robot.
+ */
+function entityJoints(
+  mjModel: MjModel,
+  entity: string | null | undefined,
+  candidates: number[],
+): number[] {
+  if (!entity) return candidates;
+  const names = decodeJointNames(mjModel);
+  const owned = candidates.filter(j => names[j].startsWith(`${entity}/`));
+  if (owned.length > 0) return owned;
+  return names.some(name => name.includes('/')) ? [] : candidates;
+}
+
+/** The free joint carrying `entity`'s root, or -1 when the model holds none of its own. */
+export function findEntityFreeJoint(mjModel: MjModel, entity?: string | null): number {
+  const free: number[] = [];
+  for (let j = 0; j < mjModel.njnt; j++) {
+    if (mjModel.jnt_type[j] === 0) free.push(j); // mjJNT_FREE
+  }
+  return entityJoints(mjModel, entity, free)[0] ?? -1;
+}
+
+/**
+ * What `joint_ids` indexes: the entity's 1-DoF joints in model order, as mjlab's
+ * `Entity.joint_names` lists them. The model's own joint list is not the same — it
+ * includes the free joint, whose `qpos[0]` is the root's x, not an angle.
+ */
+function entityJointIds(mjModel: MjModel, entity: string | null | undefined): number[] {
+  const hinges: number[] = [];
+  for (let j = 0; j < mjModel.njnt; j++) {
+    if (mjModel.jnt_type[j] >= 2) hinges.push(j); // not mjJNT_FREE / mjJNT_BALL
+  }
+  return entityJoints(mjModel, entity, hinges);
+}
+
+/** The value a target's `field` was written with, or undefined. */
+function writtenValue(
+  target: WriteTarget,
+  values: WriteValues,
+  field: string,
+): WriteValues[string] | undefined {
+  const index = target.fields?.indexOf(field) ?? -1;
+  const key = (index >= 0 ? target.outputs?.[index] : undefined) ?? `${target.kind}__${field}`;
+  return values[key];
+}
+
+/**
  * Apply one write target to `mjData`, returning whether anything was written. False for a
  * model with no such target, so a scene mismatch degrades rather than throwing.
  */
@@ -56,9 +114,14 @@ export function applyEntityWrite(
     case 'joint_state':
       return writeJointState(mjModel, mjData, target, values);
     case 'root_pose':
-      return writeRootPose(mjModel, mjData, values['root_pose__pose']);
+      return writeRootPose(mjModel, mjData, target, writtenValue(target, values, 'pose'));
     case 'root_velocity':
-      return writeRootVelocity(mjModel, mjData, values['root_velocity__velocity']);
+      return writeRootVelocity(
+        mjModel,
+        mjData,
+        target,
+        writtenValue(target, values, 'velocity'),
+      );
     default:
       return false;
   }
@@ -78,27 +141,10 @@ export function applyEntityWrites(
   return applied;
 }
 
-/**
- * What `joint_ids` indexes: the entity's 1-DoF joints in model order, as mjlab's
- * `Entity.joint_names` lists them. The model's own joint list is not the same — it
- * includes the free joint, whose `qpos[0]` is the root's x, not an angle.
- */
-function entityJointIds(mjModel: MjModel, entity: string | null | undefined): number[] {
-  const ids: number[] = [];
-  for (let j = 0; j < mjModel.njnt; j++) {
-    if (mjModel.jnt_type[j] >= 2) ids.push(j); // not mjJNT_FREE / mjJNT_BALL
-  }
-  if (!entity) return ids;
-  const names = decodeJointNames(mjModel);
-  const owned = ids.filter(j => names[j].startsWith(`${entity}/`));
-  // Unprefixed names mean a single-entity scene, where every joint is the entity's.
-  return owned.length > 0 ? owned : ids;
-}
-
 function resolveJointIds(mjModel: MjModel, target: WriteTarget): number[] {
   const all = entityJointIds(mjModel, target.entity);
   const ids = target.joint_ids;
-  if (ids === undefined || ids === 'all') return all;
+  if (ids === undefined || ids === null || ids === 'all') return all;
   return ids.map(i => all[i] ?? -1);
 }
 
@@ -108,45 +154,82 @@ function writeJointState(
   target: WriteTarget,
   values: WriteValues,
 ): boolean {
-  const position = values['joint_state__position'];
-  const velocity = values['joint_state__velocity'];
+  const position = writtenValue(target, values, 'position');
+  const velocity = writtenValue(target, values, 'velocity');
   if (!position && !velocity) return false;
+  let wrote = 0;
   const jointIds = resolveJointIds(mjModel, target);
   for (let i = 0; i < jointIds.length; i++) {
     const j = jointIds[i];
     if (j < 0 || j >= mjModel.njnt) continue;
     if (position && i < position.length) {
       mjData.qpos[mjModel.jnt_qposadr[j]] = position[i];
+      wrote++;
     }
     if (velocity && i < velocity.length) {
       mjData.qvel[mjModel.jnt_dofadr[j]] = velocity[i];
+      wrote++;
     }
   }
-  return true;
+  return wrote > 0;
 }
 
 function writeRootPose(
   mjModel: MjModel,
   mjData: MjData,
+  target: WriteTarget,
   pose: WriteValues[string] | undefined,
 ): boolean {
   if (!pose || pose.length < 7) return false;
-  const j = findFreeJoint(mjModel);
+  const j = findEntityFreeJoint(mjModel, target.entity);
   if (j < 0) return false;
   const adr = mjModel.jnt_qposadr[j];
   for (let i = 0; i < 7; i++) mjData.qpos[adr + i] = pose[i];
   return true;
 }
 
+/** Rotate `v` by the conjugate of the (w, x, y, z) quaternion `q` — mjlab's `quat_apply_inverse`. */
+function rotateByQuatInverse(
+  q: ArrayLike<number>,
+  qAdr: number,
+  v: ArrayLike<number>,
+  vAdr: number,
+): [number, number, number] {
+  // Conjugate, so the rotation runs world -> body.
+  const w = q[qAdr];
+  const x = -q[qAdr + 1];
+  const y = -q[qAdr + 2];
+  const z = -q[qAdr + 3];
+  const vx = v[vAdr];
+  const vy = v[vAdr + 1];
+  const vz = v[vAdr + 2];
+  // v' = v + w * t + u x t, with t = 2 * (u x v) and u = (x, y, z).
+  const tx = 2 * (y * vz - z * vy);
+  const ty = 2 * (z * vx - x * vz);
+  const tz = 2 * (x * vy - y * vx);
+  return [
+    vx + w * tx + (y * tz - z * ty),
+    vy + w * ty + (z * tx - x * tz),
+    vz + w * tz + (x * ty - y * tx),
+  ];
+}
+
 function writeRootVelocity(
   mjModel: MjModel,
   mjData: MjData,
+  target: WriteTarget,
   velocity: WriteValues[string] | undefined,
 ): boolean {
   if (!velocity || velocity.length < 6) return false;
-  const j = findFreeJoint(mjModel);
+  const j = findEntityFreeJoint(mjModel, target.entity);
   if (j < 0) return false;
+  // A free joint's qvel holds world-frame linear and *body*-frame angular velocity, while
+  // the term wrote both in the world frame, as mjlab's `write_root_velocity` takes them.
+  // The quaternion comes from qpos, so a pose written first is the one used — mjlab's
+  // order too, and what `write_root_state_to_sim` splits into.
+  const angB = rotateByQuatInverse(mjData.qpos, mjModel.jnt_qposadr[j] + 3, velocity, 3);
   const adr = mjModel.jnt_dofadr[j];
-  for (let i = 0; i < 6; i++) mjData.qvel[adr + i] = velocity[i];
+  for (let i = 0; i < 3; i++) mjData.qvel[adr + i] = velocity[i];
+  for (let i = 0; i < 3; i++) mjData.qvel[adr + 3 + i] = angB[i];
   return true;
 }

--- a/src/mjswan/template/src/core/observation/HistoryObservation.ts
+++ b/src/mjswan/template/src/core/observation/HistoryObservation.ts
@@ -4,16 +4,18 @@
  * `PolicyRunner`'s group-level buffer would give step-major order. That is also why a
  * group with per-term history does not fuse.
  *
- * `offsets` generalises the count: dense `history_length: n` arrives as `[0..n-1]`, and
- * a policy trained on sparse look-back names its offsets directly. The buffer holds
- * `max(offsets) + 1` frames; only the named ones reach the output.
+ * `offsets` generalises the count: dense `history_length: n` arrives as `[n-1..0]`, the
+ * chronological stack mjlab's history buffer flattens, and a policy trained on a sparse
+ * or reversed window names its offsets directly. The buffer holds `max(offsets) + 1`
+ * frames; only the named ones reach the output.
  */
 
 import { ObservationBase, type ObservationConfig } from './ObservationBase';
 import type { PolicyState } from '../policy/types';
 import type { PolicyRunner } from '../policy/PolicyRunner';
 
-/** Write `frame` element-major at slot `index` of `count`: `[a_t, a_{t-1}, …, b_t, …]`. */
+/** Write `frame` element-major at slot `index` of `count`: `[a_0, a_1, …, b_0, …]`, each
+ * element's own frames adjacent. */
 export function writeInterleavedFrame(
   out: Float32Array,
   frame: Float32Array,
@@ -33,7 +35,8 @@ export function historyOffsets(entry: ObservationConfig): number[] | null {
   }
   const length = Math.trunc(Number((entry as { history_length?: unknown }).history_length) || 0);
   if (length <= 1) return null;
-  return Array.from({ length }, (_, i) => i);
+  // Oldest frame first, as mjlab's `CircularBuffer.buffer` flattens it.
+  return Array.from({ length }, (_, i) => length - 1 - i);
 }
 
 export class HistoryObservation extends ObservationBase {
@@ -94,7 +97,7 @@ export class HistoryObservation extends ObservationBase {
     return this.gather();
   }
 
-  /** Frame-major (`[frame_t, frame_{t-1}, …]`), or element-major when interleaved. */
+  /** Frame-major, one full vector per offset in order, or element-major when interleaved. */
   private gather(): Float32Array {
     const width = this.base.size;
     const out = new Float32Array(width * this.offsets.length);

--- a/src/mjswan/template/src/core/observation/__tests__/HistoryObservation.test.ts
+++ b/src/mjswan/template/src/core/observation/__tests__/HistoryObservation.test.ts
@@ -4,8 +4,9 @@
  *
  * The cases that matter are the ones a wrong buffer makes *plausible* rather than
  * obviously broken: the offset→frame mapping (an off-by-one reads last step's value
- * forever), priming after a reset (a history of zeros the policy never saw in
- * training), and sparse offsets sizing the term by the offsets they name rather
+ * forever), the direction a dense count stacks in (reversing it keeps the width and
+ * runs time backwards), priming after a reset (a history of zeros the policy never saw
+ * in training), and sparse offsets sizing the term by the offsets they name rather
  * than by how far back they reach.
  */
 import { describe, expect, it } from 'vitest';
@@ -45,8 +46,8 @@ function build(config: ObservationConfig): { history: HistoryObservation; base: 
 }
 
 describe('historyOffsets', () => {
-  it('expands a dense length into consecutive offsets', () => {
-    expect(historyOffsets({ name: 'x', history_length: 3 })).toEqual([0, 1, 2]);
+  it('expands a dense length oldest-frame-first, as mjlab flattens its buffer', () => {
+    expect(historyOffsets({ name: 'x', history_length: 3 })).toEqual([2, 1, 0]);
   });
 
   it('treats no history and a single frame alike — nothing to stack', () => {
@@ -73,12 +74,18 @@ describe('HistoryObservation', () => {
     expect(Array.from(await history.compute(STATE))).toEqual([1, 10, 1, 10, 1, 10]);
   });
 
-  it('shifts frame-major, newest first', async () => {
+  it('shifts frame-major, oldest first', async () => {
     const { history } = build({ name: 'x', history_length: 3 });
     await history.compute(STATE);
-    expect(Array.from(await history.compute(STATE))).toEqual([2, 20, 1, 10, 1, 10]);
-    expect(Array.from(await history.compute(STATE))).toEqual([3, 30, 2, 20, 1, 10]);
-    // Frame 1 has now fallen off the end of a 3-deep buffer.
+    expect(Array.from(await history.compute(STATE))).toEqual([1, 10, 1, 10, 2, 20]);
+    expect(Array.from(await history.compute(STATE))).toEqual([1, 10, 2, 20, 3, 30]);
+    // Frame 1 has now fallen off the start of a 3-deep buffer.
+    expect(Array.from(await history.compute(STATE))).toEqual([2, 20, 3, 30, 4, 40]);
+  });
+
+  it('takes a newest-first stack from offsets, which a count no longer spells', async () => {
+    const { history } = build({ name: 'x', history_offsets: [0, 1, 2] });
+    for (let i = 0; i < 3; i++) await history.compute(STATE);
     expect(Array.from(await history.compute(STATE))).toEqual([4, 40, 3, 30, 2, 20]);
   });
 
@@ -101,7 +108,7 @@ describe('HistoryObservation', () => {
   it('lays the stack out element-major when interleaved', async () => {
     const { history } = build({ name: 'x', history_length: 2, history_interleaved: true });
     await history.compute(STATE);
-    // [e0_t, e0_t-1, e1_t, e1_t-1] rather than [e0_t, e1_t, e0_t-1, e1_t-1].
-    expect(Array.from(await history.compute(STATE))).toEqual([2, 1, 20, 10]);
+    // [e0_t-1, e0_t, e1_t-1, e1_t] rather than [e0_t-1, e1_t-1, e0_t, e1_t].
+    expect(Array.from(await history.compute(STATE))).toEqual([1, 2, 10, 20]);
   });
 });

--- a/src/mjswan/template/src/core/policy/PolicyRunner.ts
+++ b/src/mjswan/template/src/core/policy/PolicyRunner.ts
@@ -162,10 +162,10 @@ export class PolicyRunner {
           for (let i = 0; i < history.steps; i++) buffer.set(frame, i * frame.length);
           delete this.historyNeedsPrime[key];
         } else {
-          for (let i = buffer.length - 1; i >= frame.length; i--) {
-            buffer[i] = buffer[i - frame.length];
-          }
-          buffer.set(frame, 0);
+          // Shift the oldest frame out the front; the newest lands last, the order
+          // `history_length` and `HistoryObservation` use.
+          buffer.copyWithin(0, frame.length);
+          buffer.set(frame, buffer.length - frame.length);
         }
         // The buffer is frame-major either way; interleaving is an output layout.
         outputs[key] = history.interleaved

--- a/src/mjswan/template/src/core/policy/__tests__/groupHistory.test.ts
+++ b/src/mjswan/template/src/core/policy/__tests__/groupHistory.test.ts
@@ -2,9 +2,9 @@
  * `PolicyRunner`'s group-level frame stack: the `{components, history_steps,
  * interleaved}` config shape a hand-authored `policy.json` can declare.
  *
- * Both layouts are the same length, so getting `interleaved` wrong reaches the policy
- * as reordered numbers rather than as a size error — hence a test per layout, and one
- * pinning the group stack against the per-term one.
+ * Both layouts are the same length, so getting `interleaved` — or the direction the
+ * stack grows in — wrong reaches the policy as reordered numbers rather than as a size
+ * error, hence a test per layout and one pinning the size.
  */
 import { describe, expect, it } from 'vitest';
 
@@ -53,18 +53,18 @@ async function collect(instance: PolicyRunner): Promise<number[]> {
 }
 
 describe('PolicyRunner group history', () => {
-  it('stacks frame-major by default', async () => {
+  it('stacks frame-major, oldest first, as a per-term stack does', async () => {
     const instance = await runner(false);
     // Primed: every slot holds frame 1.
     expect(await collect(instance)).toEqual([1, 10, 1, 10]);
-    expect(await collect(instance)).toEqual([2, 20, 1, 10]);
+    expect(await collect(instance)).toEqual([1, 10, 2, 20]);
   });
 
   it('lays the stack out element-major when interleaved', async () => {
     const instance = await runner(true);
     expect(await collect(instance)).toEqual([1, 1, 10, 10]);
-    // [e0_t, e0_t-1, e1_t, e1_t-1] rather than [e0_t, e1_t, e0_t-1, e1_t-1].
-    expect(await collect(instance)).toEqual([2, 1, 20, 10]);
+    // [e0_t-1, e0_t, e1_t-1, e1_t] rather than [e0_t-1, e1_t-1, e0_t, e1_t].
+    expect(await collect(instance)).toEqual([1, 2, 10, 20]);
   });
 
   it('keeps the group size the same either way', async () => {

--- a/tests/test_mjlab_adapter.py
+++ b/tests/test_mjlab_adapter.py
@@ -190,8 +190,7 @@ class TestAdaptObservations:
         assert term.history_steps is None
 
     def test_mjlab_group_history_carries_over(self):
-        """The group's own count stays on the group, where the serializer applies it to
-        every term — as mjlab's manager does."""
+        """The count stays on the group; the serializer applies it, as mjlab does."""
         mjlab_group = FakeMjlabObsGroupCfg(
             terms={
                 "jp": FakeMjlabObsTermCfg(func=_make_mjlab_obs_func("joint_pos_rel")),
@@ -209,11 +208,8 @@ class TestAdaptObservations:
         assert group.terms["jv"].history_length == 2
 
     def test_mjlab_cfg_subclass_is_still_adapted(self):
-        """A task subclassing an mjlab config to add a field of its own is still mjlab.
-
-        The subclass reports its own module, so a check on the class alone passes it
-        through unadapted — and the mjlab *terms* inside it then reach the serializer,
-        which fails on the first mjswan-only field.
+        """A task's subclass of an mjlab config is still mjlab: it reports its own
+        module, so checking the leaf class lets mjlab terms reach the serializer.
         """
 
         class TaskObsGroupCfg(FakeMjlabObsGroupCfg):  # defined here, not in mjlab

--- a/tests/test_mjlab_adapter.py
+++ b/tests/test_mjlab_adapter.py
@@ -177,6 +177,7 @@ class TestAdaptObservations:
         assert term.params == {"world_frame": True}
 
     def test_mjlab_obs_scale_and_history(self):
+        """A count carries over as a count: both sides stack oldest frame first."""
         mjlab_func = _make_mjlab_obs_func("joint_pos_rel")
         mjlab_term = FakeMjlabObsTermCfg(func=mjlab_func, scale=0.5, history_length=3)
         mjlab_group = FakeMjlabObsGroupCfg(terms={"jp": mjlab_term})
@@ -186,6 +187,50 @@ class TestAdaptObservations:
         term = result["policy"].terms["jp"]
         assert term.scale == 0.5
         assert term.history_length == 3
+        assert term.history_steps is None
+
+    def test_mjlab_group_history_carries_over(self):
+        """The group's own count stays on the group, where the serializer applies it to
+        every term — as mjlab's manager does."""
+        mjlab_group = FakeMjlabObsGroupCfg(
+            terms={
+                "jp": FakeMjlabObsTermCfg(func=_make_mjlab_obs_func("joint_pos_rel")),
+                "jv": FakeMjlabObsTermCfg(
+                    func=_make_mjlab_obs_func("joint_vel_rel"), history_length=2
+                ),
+            },
+            history_length=4,
+        )
+
+        result = adapt_observations({"policy": mjlab_group})
+        assert result is not None
+        group = result["policy"]
+        assert group.history_length == 4
+        assert group.terms["jv"].history_length == 2
+
+    def test_mjlab_cfg_subclass_is_still_adapted(self):
+        """A task subclassing an mjlab config to add a field of its own is still mjlab.
+
+        The subclass reports its own module, so a check on the class alone passes it
+        through unadapted — and the mjlab *terms* inside it then reach the serializer,
+        which fails on the first mjswan-only field.
+        """
+
+        class TaskObsGroupCfg(FakeMjlabObsGroupCfg):  # defined here, not in mjlab
+            pass
+
+        group = TaskObsGroupCfg(
+            terms={
+                "jp": FakeMjlabObsTermCfg(func=_make_mjlab_obs_func("joint_pos_rel"))
+            },
+            history_length=4,
+        )
+
+        result = adapt_observations({"policy": group})
+        assert result is not None
+        assert isinstance(result["policy"], ObservationGroupCfg)
+        assert isinstance(result["policy"].terms["jp"], ObservationTermCfg)
+        assert result["policy"].history_length == 4
 
     def test_mjlab_asset_cfg_kept_intact_for_tracing(self):
         # A plain (non-Binding) func is traced to ONNX at build time (ADR 0005) via `func(env,

--- a/tests/test_observation_history.py
+++ b/tests/test_observation_history.py
@@ -10,7 +10,7 @@ group carrying per-term history must not fuse: a fused graph emits one
 concatenation, which the runtime could only stack whole, giving step-major order
 where mjlab gives term-major.
 
-The runtime half of the contract (offset → frame, priming, layout) is pinned in
+The runtime half of the contract (offset → frame, order, priming, layout) is pinned in
 `core/observation/__tests__/HistoryObservation.test.ts`.
 """
 
@@ -68,6 +68,14 @@ def test_group_history_overrides_a_terms_own_length():
     assert _entry(_term(history_length=2), group_history=5)["history_length"] == 5
 
 
+def test_a_group_zero_switches_history_off():
+    """mjlab assigns the group's count whenever it is set, so an explicit 0 is an
+    instruction, not an absent value."""
+    entry = _entry(_term(history_length=4), group_history=0)
+    assert "history_length" not in entry
+    assert "history_offsets" not in entry
+
+
 def test_interleaved_only_ships_alongside_history():
     """It describes a stack's layout, so without a stack it says nothing."""
     assert "history_interleaved" not in _entry(_term(history_interleaved=True))
@@ -103,3 +111,8 @@ def test_only_a_stackless_group_fuses(term_cfg, fusable):
 def test_group_level_history_also_blocks_fusion():
     group = ObservationGroupCfg(terms={"a": _term()}, history_length=3)
     assert _group_is_fusable(group) is False
+
+
+def test_a_group_zero_lets_a_stacking_term_fuse():
+    group = ObservationGroupCfg(terms={"a": _term(history_length=4)}, history_length=0)
+    assert _group_is_fusable(group) is True

--- a/tests/test_observation_history.py
+++ b/tests/test_observation_history.py
@@ -69,8 +69,7 @@ def test_group_history_overrides_a_terms_own_length():
 
 
 def test_a_group_zero_switches_history_off():
-    """mjlab assigns the group's count whenever it is set, so an explicit 0 is an
-    instruction, not an absent value."""
+    """mjlab assigns the group's count whenever set, so an explicit 0 is an instruction."""
     entry = _entry(_term(history_length=4), group_history=0)
     assert "history_length" not in entry
     assert "history_offsets" not in entry

--- a/tests/test_onnx_command_parity.py
+++ b/tests/test_onnx_command_parity.py
@@ -42,7 +42,7 @@ pytestmark = [pytest.mark.slow, pytest.mark.mjlab]
 COMMAND_TASKS = [
     # Stateful, with an `entity_write` side effect on the cube (§3b).
     pytest.param("Mjlab-Lift-Cube-Yam", "lift_height", id="lift-cube-yam"),
-    # Heading tracking as a dynamic slot; needs the examples-side override.
+    # Heading tracking as a dynamic slot, through the override mjswan itself binds.
     pytest.param("Mjlab-Velocity-Flat-Unitree-G1", "twist", id="velocity-flat-g1"),
     pytest.param("Mjlab-Velocity-Flat-Unitree-Go1", "twist", id="velocity-flat-go1"),
 ]
@@ -50,12 +50,11 @@ COMMAND_TASKS = [
 
 @pytest.fixture(scope="module", autouse=True)
 def _registrations() -> None:
-    """The traced command bodies live author-side; load them before resolving.
+    """`LiftingCommandCfg`'s traced body lives author-side; load it before resolving.
 
-    `examples/mjlab/defaults/commands` is what binds `UniformVelocityCommandCfg`
-    and `LiftingCommandCfg` to their traced bodies. Without it the adapter raises
-    for an unregistered class — which is how a missing import surfaces, and is the
-    same footgun that cost `g1_spinkick` its RSI jitter.
+    Without it the adapter raises for an unregistered class — which is how a missing
+    import surfaces, and is the same footgun that cost `g1_spinkick` its RSI jitter.
+    `UniformVelocityCommandCfg` no longer needs it: mjswan binds that one itself.
     """
     pytest.importorskip("examples.mjlab.defaults.commands")
 

--- a/tests/test_onnx_command_parity.py
+++ b/tests/test_onnx_command_parity.py
@@ -52,9 +52,9 @@ COMMAND_TASKS = [
 def _registrations() -> None:
     """`LiftingCommandCfg`'s traced body lives author-side; load it before resolving.
 
-    Without it the adapter raises for an unregistered class — which is how a missing
-    import surfaces, and is the same footgun that cost `g1_spinkick` its RSI jitter.
-    `UniformVelocityCommandCfg` no longer needs it: mjswan binds that one itself.
+    Without it the adapter raises for an unregistered class — the footgun that cost
+    `g1_spinkick` its RSI jitter. `UniformVelocityCommandCfg` needs no import: mjswan
+    binds that one itself.
     """
     pytest.importorskip("examples.mjlab.defaults.commands")
 

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -680,12 +680,9 @@ class TestFlatPatchSpawnTraces:
 class TestWriteTargetEntity:
     """Which entity a traced write lands on, and how many it may land on.
 
-    The browser resolves a root write through this name, and a scene with two floating
-    bodies — a robot and a thrown ball — has a free joint each. Reading the name off an
-    `asset_cfg` param only is what left it `null`: mjlab's own terms take that param, but
-    a task's term is free to take a plain `ball_name`, and then the write went to
-    whichever free joint came first in the model. The robot got launched; the ball never
-    moved. mjlab writes per entity, so the tracer keys captures the same way.
+    Reading the name off an `asset_cfg` param alone left it `null` for a term taking a
+    plain `ball_name`, and the write then went to the model's *first* free joint: the
+    robot got launched, the ball never moved. mjlab writes per entity, so does the key.
     """
 
     @staticmethod
@@ -779,8 +776,7 @@ class TestWriteTargetEntity:
         assert [w["entity"] for w in export.write_targets] == ["robot"]
 
     def test_two_entities_each_get_their_own_target(self):
-        """One write per entity reaches the browser, as in mjlab — the robot's root and
-        the ball's are different addresses."""
+        """One write per entity, as in mjlab: the two roots are different addresses."""
         torch = pytest.importorskip("torch")
 
         def throw_both(env, env_ids):
@@ -800,8 +796,7 @@ class TestWriteTargetEntity:
         ]
 
     def test_a_root_state_write_splits_into_pose_and_velocity(self):
-        """mjlab's own split of the 13-wide state, so a term using it traces as well as
-        one calling the two writes itself."""
+        """mjlab's own split of the 13-wide state, so such a term traces too."""
         torch = pytest.importorskip("torch")
 
         def reset(env, env_ids):
@@ -816,8 +811,7 @@ class TestWriteTargetEntity:
         ]
 
     def test_iterating_the_scene_never_touches_the_live_entities(self):
-        """A term walking `scene.entities` gets recording stand-ins: writing through the
-        live ones would move the tracing env under every term traced after it."""
+        """Stand-ins: writing through the live ones would move the sim under later terms."""
         torch = pytest.importorskip("torch")
         env = self._env()
 
@@ -841,8 +835,7 @@ class TestWriteTargetEntity:
 
 
 def test_reset_scene_to_default_needs_no_graph():
-    """The runtime's own reset already restores every entity's default state, so mjlab's
-    default event has nothing left to write."""
+    """The runtime's reset already restores every default, so nothing is left to write."""
     from mjswan._onnx_build import _EVENTS_WITH_NOTHING_TO_WRITE
 
     assert "reset_scene_to_default" in _EVENTS_WITH_NOTHING_TO_WRITE

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -677,6 +677,177 @@ class TestFlatPatchSpawnTraces:
         )
 
 
+class TestWriteTargetEntity:
+    """Which entity a traced write lands on, and how many it may land on.
+
+    The browser resolves a root write through this name, and a scene with two floating
+    bodies — a robot and a thrown ball — has a free joint each. Reading the name off an
+    `asset_cfg` param only is what left it `null`: mjlab's own terms take that param, but
+    a task's term is free to take a plain `ball_name`, and then the write went to
+    whichever free joint came first in the model. The robot got launched; the ball never
+    moved. mjlab writes per entity, so the tracer keys captures the same way.
+    """
+
+    @staticmethod
+    def _env():
+        torch = pytest.importorskip("torch")
+
+        class _Data:
+            def __init__(self):
+                self.root_link_pos_w = torch.zeros(1, 3)
+                self.default_root_state = torch.zeros(1, 13)
+
+        class _Entity:
+            def __init__(self):
+                self.data = _Data()
+                self.written = 0
+
+            def write_root_link_pose_to_sim(self, pose, env_ids=None):
+                self.written += 1
+
+            def write_root_link_velocity_to_sim(self, velocity, env_ids=None):
+                self.written += 1
+
+            def write_root_state_to_sim(self, root_state, env_ids=None):
+                self.written += 1
+
+        class _Scene(dict):
+            def __getitem__(self, name):
+                return self.setdefault(name, _Entity())
+
+            @property
+            def entities(self):
+                return {name: self[name] for name in ("robot", "ball")}
+
+        class _Env:
+            def __init__(self):
+                self.scene = _Scene()
+                self.num_envs = 1
+                self.device = "cpu"
+
+        return _Env()
+
+    @staticmethod
+    def _trace(func, params, env=None):
+        pytest.importorskip("mjlab")
+        pytest.importorskip("torch")
+        from mjswan.compile import trace_event_term
+
+        return trace_event_term(
+            func,
+            params,
+            env if env is not None else TestWriteTargetEntity._env(),
+            name="throw",
+            mode="interval",
+        )
+
+    def test_the_write_names_the_entity_it_was_made_on(self):
+        torch = pytest.importorskip("torch")
+
+        def throw(env, env_ids, ball_name="ball"):
+            ball = env.scene[ball_name]
+            ball.write_root_link_pose_to_sim(torch.zeros(1, 7), env_ids=env_ids)
+            ball.write_root_link_velocity_to_sim(torch.zeros(1, 6), env_ids=env_ids)
+
+        export = self._trace(throw, {"ball_name": "ball"})
+        assert [(w["kind"], w["entity"]) for w in export.write_targets] == [
+            ("root_pose", "ball"),
+            ("root_velocity", "ball"),
+        ]
+        # The graph output carries the entity too, so a second one cannot collide.
+        assert [w["outputs"] for w in export.write_targets] == [
+            ["ball__root_pose__pose"],
+            ["ball__root_velocity__velocity"],
+        ]
+        assert export.output_names == [
+            "ball__root_pose__pose",
+            "ball__root_velocity__velocity",
+        ]
+
+    def test_an_asset_cfg_still_names_it(self):
+        """mjlab's own convention keeps working, and stays the fallback."""
+        torch = pytest.importorskip("torch")
+        pytest.importorskip("mjlab")
+        from mjlab.managers.scene_entity_config import SceneEntityCfg
+
+        def reset(env, env_ids, asset_cfg=None):
+            env.scene[asset_cfg.name].write_root_link_pose_to_sim(
+                torch.zeros(1, 7), env_ids=env_ids
+            )
+
+        export = self._trace(reset, {"asset_cfg": SceneEntityCfg("robot")})
+        assert [w["entity"] for w in export.write_targets] == ["robot"]
+
+    def test_two_entities_each_get_their_own_target(self):
+        """One write per entity reaches the browser, as in mjlab — the robot's root and
+        the ball's are different addresses."""
+        torch = pytest.importorskip("torch")
+
+        def throw_both(env, env_ids):
+            for name in ("ball", "robot"):
+                env.scene[name].write_root_link_pose_to_sim(
+                    torch.zeros(1, 7), env_ids=env_ids
+                )
+
+        export = self._trace(throw_both, {})
+        assert [(w["kind"], w["entity"]) for w in export.write_targets] == [
+            ("root_pose", "ball"),
+            ("root_pose", "robot"),
+        ]
+        assert export.output_names == [
+            "ball__root_pose__pose",
+            "robot__root_pose__pose",
+        ]
+
+    def test_a_root_state_write_splits_into_pose_and_velocity(self):
+        """mjlab's own split of the 13-wide state, so a term using it traces as well as
+        one calling the two writes itself."""
+        torch = pytest.importorskip("torch")
+
+        def reset(env, env_ids):
+            env.scene["ball"].write_root_state_to_sim(
+                torch.zeros(1, 13), env_ids=env_ids
+            )
+
+        export = self._trace(reset, {})
+        assert [(w["kind"], w["entity"]) for w in export.write_targets] == [
+            ("root_pose", "ball"),
+            ("root_velocity", "ball"),
+        ]
+
+    def test_iterating_the_scene_never_touches_the_live_entities(self):
+        """A term walking `scene.entities` gets recording stand-ins: writing through the
+        live ones would move the tracing env under every term traced after it."""
+        torch = pytest.importorskip("torch")
+        env = self._env()
+
+        def reset_all(env, env_ids):
+            for entity in env.scene.entities.values():
+                entity.write_root_link_pose_to_sim(torch.zeros(1, 7), env_ids=env_ids)
+
+        export = self._trace(reset_all, {}, env=env)
+        assert {w["entity"] for w in export.write_targets} == {"robot", "ball"}
+        assert [e.written for e in env.scene.entities.values()] == [0, 0]
+
+    def test_an_uncaptured_write_is_refused_not_forwarded(self):
+        """Forwarding it would mutate the live env and emit no graph output for it."""
+        torch = pytest.importorskip("torch")
+
+        def spin(env, env_ids):
+            env.scene["robot"].write_root_link_velocity_b_to_sim(torch.zeros(1, 6))
+
+        with pytest.raises(ValueError, match="does not capture"):
+            self._trace(spin, {})
+
+
+def test_reset_scene_to_default_needs_no_graph():
+    """The runtime's own reset already restores every entity's default state, so mjlab's
+    default event has nothing left to write."""
+    from mjswan._onnx_build import _EVENTS_WITH_NOTHING_TO_WRITE
+
+    assert "reset_scene_to_default" in _EVENTS_WITH_NOTHING_TO_WRITE
+
+
 class TestApplyTerrainSpawn:
     """`add_scene_mjlab` swaps mjlab's root-spawn reset once the terrain has patches."""
 

--- a/tests/test_velocity_command.py
+++ b/tests/test_velocity_command.py
@@ -2,18 +2,11 @@
 
 Layer: L1 (no env build, no trace — the term is constructed against a stand-in env).
 
-mjswan cannot trace `UniformVelocityCommand` as written: it draws with
-`Tensor.uniform_`, which the tracer's RNG spy cannot see, and assigns through
-`env_ids`, which branches on live data. `mjswan.envs.mdp.commands` rebinds the two
-bodies to equivalents built from `sample_uniform` and `torch.where`.
-
-That makes the rewrite a second copy of mjlab's math, and **the command parity harness
-cannot check it**: `run_command_parity` traces the *overridden* term and compares the
-graph against that same term, so it only ever establishes "graph == override". Whether
-"override == mjlab" holds is what this file pins. Getting it wrong is silent — the
-policy receives a well-formed command of the right width that mjlab would not have
-issued (a forward-only env that never goes forward-only, say, which is 20% of
-resamples in mjlab's own velocity tasks).
+The rewrite in `mjswan.envs.mdp.commands` is a second copy of mjlab's math, and the
+parity harness cannot check it: `run_command_parity` traces the *overridden* term and
+compares the graph against that same term, so it only establishes "graph == override".
+"override == mjlab" is what this file pins. Getting it wrong is silent — a well-formed
+command of the right width that mjlab would not have issued.
 """
 
 from __future__ import annotations
@@ -36,11 +29,8 @@ HEADING_W = 0.7
 
 
 class _FakeEnv:
-    """Enough env for `CommandTerm.__init__`: `num_envs`, `device`, and the entity.
-
-    `ManagerTermBase` only stores `env` and reads those through properties, so no
-    scene is compiled and the test stays out of the `slow` tier.
-    """
+    """Enough env for `CommandTerm.__init__`: `num_envs`, `device`, and the entity. No
+    scene is compiled, so these tests stay out of the `slow` tier."""
 
     def __init__(self, heading: float = HEADING_W):
         robot = type(
@@ -75,8 +65,7 @@ def _cfg(**overrides) -> UniformVelocityCommandCfg:
 
 
 #: A command mid-episode. `ang_vel_z` is deliberately *not* what heading tracking would
-#: produce for (`heading_target`, `HEADING_W`) — otherwise the heading cases pass
-#: whether or not the rewrite tracks heading at all.
+#: produce, or the heading cases pass whether the rewrite tracks heading or not.
 _SEED = {
     "vel_command_b": [[0.4, -0.3, -0.45]],
     "vel_command_w": [[0.9, 0.2, -0.1]],
@@ -102,8 +91,7 @@ def _pair(cfg):
 
 
 def test_the_binding_ships_with_mjswan():
-    """It used to live in `examples/`, so a project outside the repo could not reach it
-    and hand-wrote sliders instead."""
+    """It used to live in `examples/`, out of reach of any project outside this repo."""
     binding = _custom_registry["UniformVelocityCommandCfg"]
     assert binding.is_onnx_traced
     assert binding.command_field == "vel_command_b"
@@ -126,8 +114,7 @@ def test_update_command_matches_mjlab(heading, world, standing):
 
 
 def test_heading_tracking_actually_moves_the_yaw():
-    """Guards the test above: without this, a rewrite ignoring `is_heading_env`
-    entirely would still pass every case."""
+    """Guards the test above: a rewrite ignoring `is_heading_env` would still pass it."""
     live, _ = _pair(_cfg())
     _seed(live, heading=True, world=False, standing=False)
     live._update_command()
@@ -137,8 +124,7 @@ def test_heading_tracking_actually_moves_the_yaw():
 
 
 def test_heading_command_off_is_respected():
-    """The cfg default is `False`, and then mjlab never touches yaw — even with
-    `is_heading_env` set, which it would not have sampled."""
+    """With the cfg default `False`, mjlab never touches yaw, even with `is_heading_env`."""
     cfg = _cfg(
         heading_command=False,
         ranges=UniformVelocityCommandCfg.Ranges(
@@ -157,8 +143,8 @@ def test_heading_command_off_is_respected():
 
 
 def test_a_forward_only_env_gets_mjlabs_clamp():
-    """mjlab's velocity tasks set `rel_forward_envs=0.2`, and `play=True` does not
-    clear it, so a rewrite without this differs from mjlab one resample in five."""
+    """mjlab's velocity tasks set `rel_forward_envs=0.2` and `play=True` keeps it, so
+    without this the rewrite differs one resample in five."""
     _, rewritten = _pair(_cfg(rel_forward_envs=1.0))
     torch.manual_seed(0)
     rewritten._resample_command(torch.arange(1))

--- a/tests/test_velocity_command.py
+++ b/tests/test_velocity_command.py
@@ -1,0 +1,211 @@
+"""`UniformVelocityCommandCfg`'s trace-friendly rewrite, against the real mjlab term.
+
+Layer: L1 (no env build, no trace — the term is constructed against a stand-in env).
+
+mjswan cannot trace `UniformVelocityCommand` as written: it draws with
+`Tensor.uniform_`, which the tracer's RNG spy cannot see, and assigns through
+`env_ids`, which branches on live data. `mjswan.envs.mdp.commands` rebinds the two
+bodies to equivalents built from `sample_uniform` and `torch.where`.
+
+That makes the rewrite a second copy of mjlab's math, and **the command parity harness
+cannot check it**: `run_command_parity` traces the *overridden* term and compares the
+graph against that same term, so it only ever establishes "graph == override". Whether
+"override == mjlab" holds is what this file pins. Getting it wrong is silent — the
+policy receives a well-formed command of the right width that mjlab would not have
+issued (a forward-only env that never goes forward-only, say, which is 20% of
+resamples in mjlab's own velocity tasks).
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("mjlab")
+
+from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg  # noqa: E402
+
+from mjswan.command import _custom_registry  # noqa: E402
+from mjswan.envs.mdp.commands import bind_velocity_override  # noqa: E402
+
+HEADING_W = 0.7
+"""The stand-in robot's yaw. Non-zero so a world-frame rotation is not the identity."""
+
+
+class _FakeEnv:
+    """Enough env for `CommandTerm.__init__`: `num_envs`, `device`, and the entity.
+
+    `ManagerTermBase` only stores `env` and reads those through properties, so no
+    scene is compiled and the test stays out of the `slow` tier.
+    """
+
+    def __init__(self, heading: float = HEADING_W):
+        robot = type(
+            "_Robot",
+            (),
+            {"data": type("_Data", (), {"heading_w": torch.tensor([heading])})()},
+        )()
+        self.scene = {"robot": robot}
+        self.num_envs = 1
+        self.device = "cpu"
+
+
+def _cfg(**overrides) -> UniformVelocityCommandCfg:
+    """mjlab's own velocity-task shape: heading tracking, standing and forward envs."""
+    params = dict(
+        entity_name="robot",
+        resampling_time_range=(3.0, 8.0),
+        heading_command=True,
+        heading_control_stiffness=0.5,
+        rel_standing_envs=0.1,
+        rel_heading_envs=0.3,
+        rel_forward_envs=0.2,
+        ranges=UniformVelocityCommandCfg.Ranges(
+            lin_vel_x=(-1.0, 1.0),
+            lin_vel_y=(-1.0, 1.0),
+            ang_vel_z=(-0.5, 0.5),
+            heading=(-math.pi, math.pi),
+        ),
+    )
+    params.update(overrides)
+    return UniformVelocityCommandCfg(**params)
+
+
+#: A command mid-episode. `ang_vel_z` is deliberately *not* what heading tracking would
+#: produce for (`heading_target`, `HEADING_W`) — otherwise the heading cases pass
+#: whether or not the rewrite tracks heading at all.
+_SEED = {
+    "vel_command_b": [[0.4, -0.3, -0.45]],
+    "vel_command_w": [[0.9, 0.2, -0.1]],
+    "heading_target": [1.2],
+}
+
+
+def _seed(term, *, heading: bool, world: bool, standing: bool) -> None:
+    for name, value in _SEED.items():
+        setattr(term, name, torch.tensor(value))
+    term.is_heading_env = torch.tensor([heading])
+    term.is_world_env = torch.tensor([world])
+    term.is_standing_env = torch.tensor([standing])
+    term.is_forward_env = torch.tensor([False])
+
+
+def _pair(cfg):
+    """A live mjlab term and an identically-configured overridden one."""
+    live = cfg.build(_FakeEnv())
+    rewritten = cfg.build(_FakeEnv())
+    bind_velocity_override(rewritten)
+    return live, rewritten
+
+
+def test_the_binding_ships_with_mjswan():
+    """It used to live in `examples/`, so a project outside the repo could not reach it
+    and hand-wrote sliders instead."""
+    binding = _custom_registry["UniformVelocityCommandCfg"]
+    assert binding.is_onnx_traced
+    assert binding.command_field == "vel_command_b"
+
+
+@pytest.mark.parametrize(
+    "heading, world, standing", list(itertools.product([False, True], repeat=3))
+)
+def test_update_command_matches_mjlab(heading, world, standing):
+    """Every combination of the three per-env modes, from the same state."""
+    live, rewritten = _pair(_cfg())
+    _seed(live, heading=heading, world=world, standing=standing)
+    _seed(rewritten, heading=heading, world=world, standing=standing)
+
+    live._update_command()
+    rewritten._update_command()
+
+    assert torch.allclose(live.vel_command_b, rewritten.vel_command_b, atol=1e-6)
+    assert torch.allclose(live.vel_command_w, rewritten.vel_command_w, atol=1e-6)
+
+
+def test_heading_tracking_actually_moves_the_yaw():
+    """Guards the test above: without this, a rewrite ignoring `is_heading_env`
+    entirely would still pass every case."""
+    live, _ = _pair(_cfg())
+    _seed(live, heading=True, world=False, standing=False)
+    live._update_command()
+    assert not math.isclose(
+        live.vel_command_b[0, 2].item(), _SEED["vel_command_b"][0][2]
+    )
+
+
+def test_heading_command_off_is_respected():
+    """The cfg default is `False`, and then mjlab never touches yaw — even with
+    `is_heading_env` set, which it would not have sampled."""
+    cfg = _cfg(
+        heading_command=False,
+        ranges=UniformVelocityCommandCfg.Ranges(
+            lin_vel_x=(-1.0, 1.0), lin_vel_y=(-1.0, 1.0), ang_vel_z=(-0.5, 0.5)
+        ),
+    )
+    live, rewritten = _pair(cfg)
+    _seed(live, heading=True, world=False, standing=False)
+    _seed(rewritten, heading=True, world=False, standing=False)
+
+    live._update_command()
+    rewritten._update_command()
+
+    assert torch.allclose(live.vel_command_b, rewritten.vel_command_b, atol=1e-6)
+    assert rewritten.vel_command_b[0, 2].item() == pytest.approx(-0.45)
+
+
+def test_a_forward_only_env_gets_mjlabs_clamp():
+    """mjlab's velocity tasks set `rel_forward_envs=0.2`, and `play=True` does not
+    clear it, so a rewrite without this differs from mjlab one resample in five."""
+    _, rewritten = _pair(_cfg(rel_forward_envs=1.0))
+    torch.manual_seed(0)
+    rewritten._resample_command(torch.arange(1))
+
+    assert rewritten.is_forward_env.tolist() == [True]
+    assert rewritten.vel_command_b[0, 0].item() >= 0.3
+    assert rewritten.vel_command_b[0, 1].item() == 0.0
+    assert rewritten.vel_command_b[0, 2].item() == 0.0
+
+
+def test_the_world_frame_reference_keeps_the_unclamped_sample():
+    """mjlab copies `vel_command_w` *before* the forward clamp, so a world+forward env
+    rotates the raw sample rather than the clamped one."""
+    _, rewritten = _pair(_cfg(rel_forward_envs=1.0))
+    torch.manual_seed(0)
+    rewritten._resample_command(torch.arange(1))
+
+    assert rewritten.vel_command_w[0, 1].item() != 0.0
+    assert rewritten.vel_command_w[0, 2].item() != 0.0
+
+
+def test_the_bodies_write_nothing_the_binding_does_not_carry():
+    """A tensor the rewrite assigns but `state_fields` omits is dropped between browser
+    steps — the term would silently restart from its build-time value each frame."""
+    _, rewritten = _pair(_cfg())
+    before = {
+        name: value.clone()
+        for name, value in vars(rewritten).items()
+        if isinstance(value, torch.Tensor)
+    }
+    torch.manual_seed(0)
+    rewritten._resample_command(torch.arange(1))
+    rewritten._update_command()
+
+    changed = {
+        name
+        for name, value in vars(rewritten).items()
+        if isinstance(value, torch.Tensor)
+        and (name not in before or not torch.equal(value, before[name]))
+    }
+    declared = set(_custom_registry["UniformVelocityCommandCfg"].state_fields or [])
+    assert changed <= declared, f"undeclared state: {sorted(changed - declared)}"
+
+
+def test_an_unmodelled_cfg_field_is_refused():
+    """`init_velocity_prob` writes the robot's root state during resampling, gated on
+    that same draw. Tracing it as if absent would be a silent difference."""
+    term = _cfg(init_velocity_prob=0.5).build(_FakeEnv())
+    with pytest.raises(ValueError, match="init_velocity_prob"):
+        bind_velocity_override(term)


### PR DESCRIPTION
Four ways a traced mjlab task's fidelity slipped, plus what settling them turned up.
Three are silent; one fails the build; one leaves the task unbuildable outside this repo.

**Supersedes #97** — same ground for the first three, but the history fix now changes what
mjswan *means* by a frame count instead of translating between two meanings, so several of
that PR's moving parts (a count → offsets converter in the adapter, a "two entities is an
error" guard, a body-name lookup in the runtime) are gone rather than kept.

## 1. Observation history stacks in mjlab's order

mjlab flattens a term's `CircularBuffer` **chronologically** — oldest frame first:

```python
>>> b = CircularBuffer(max_len=3, batch_size=1, device="cpu")
>>> for v in (1., 2., 3.): b.append(torch.tensor([[v]]))
>>> b.buffer.reshape(1, -1)
tensor([[1., 2., 3.]])
```

`history_length` counted back from the *newest* frame, so every mjlab task carrying
per-term or group history handed its policy a correct-**width** observation with time
running backwards. Nothing existing could have caught it: the parity harness compares term
*bodies*, and history is orchestration around them.

**`history_length` now stacks oldest-first**, matching mjlab outright, so a count carries
over as a count and the adapter copies it instead of translating. This is a behaviour
change for hand-written configs, and the migration is one line per term:

| config | before | after |
| --- | --- | --- |
| `history_length=n`, hand-written for a newest-first checkpoint | newest first | `history_steps=tuple(range(n))` |
| `history_length=n`, from an mjlab task | newest first (the bug) | unchanged — now correct |
| `history_steps=(…)` | explicit | unchanged; still wins over `history_length` |
| `history_length` of `0` or `1` | no history | unchanged |
| a group's `history_length` | newest first | same rule as its terms |

`history_steps` keeps both things a count cannot say: a sparse window
(`(16, 8, 4, 2, 1, 0)` reaches 17 frames back contributing 6) and a different order.
The bundled Go2 policies and `gentle_humanoid`'s `prev_actions` are migrated to explicit
offsets, on the reading that they were trained newest-first — that is what the previous
code fed them, and the demos work. `splat.py` uses `history_length=1` and is untouched.

`PolicyRunner`'s group-level frame stack (the hand-authored `{components, history_steps}`
config shape) follows, so one rule holds across both history paths, and
`history_interleaved` follows the stack: `[a0_{t-n+1}, …, a0_t, a1_…]`.

A group's count now replaces its terms' whenever it is set, **`0` included**, as mjlab's
`ObservationManager` does (`if group_cfg.history_length is not None:`). An explicit `0`
used to read as "unset" and leave each term's own count standing.

## 2. A subclass of an mjlab config is still mjlab

`_is_from_mjlab` read the class's own `__module__`, so a task's **subclass** of an mjlab
`ObservationGroupCfg` — how a project adds a field mjlab has no notion of — was not
recognized, and `adapt_observations` passed the group through unadapted. The mjlab *term*
objects inside it then reached the serializer:

```
AttributeError: 'ObservationTermCfg' object has no attribute 'history_steps'
  File "mjswan/_onnx_build.py", line 231, in _group_is_fusable
```

The CHANGELOG already records fixes of exactly this shape for the command and action
adapters ("maps a config wherever its class lives"); the observation and termination paths
still gated on the leaf class. The whole MRO is consulted now, and the module docstring
describes the walk it actually does.

## 3. An event's write lands on the entity it was made on

The write target's entity came from an `asset_cfg` param:

```python
asset_cfg = params.get("asset_cfg")
entity = getattr(asset_cfg, "name", None)
```

mjlab's own terms carry that param, but a task's term need not — a thrown ball's launcher
is `throw_ball_on_dwell(env, env_ids, ball_name="ball", …)` — so the target serialized as
`"entity": null`, and the runtime sent every root write to `findFreeJoint(mjModel)`, the
model's **first** free joint. With a robot and a ball in one scene, that is the robot: each
throw teleported the G1 to the launch point and gave it the ball's velocity, while the ball
sat where the reset had parked it. Clean build, correct graph, wrong body.

**How mjlab does it.** An `Entity` walks its own spec joints, looks each up in the compiled
model **by joint name**, and keeps `free_joint_q_adr` / `free_joint_v_adr` from that; at
most one free joint per entity, more raises at construction. There is no
first-free-joint fallback anywhere, and `env.scene["nobody"]` raises. Matching that:

- **Python.** A capture is keyed by `(entity, kind)`, because mjlab writes per entity, so
  one term may write several — each write target names the graph outputs holding its values
  (`ball__root_pose__pose`), and a bundle built before this keeps reading the old
  unprefixed `kind__field` names. `asset_cfg` stays the fallback for a write the proxies
  could not attribute, and its `joint_ids` scope its own entity only.
- **TypeScript.** `findEntityFreeJoint` resolves through the **joint** name prefix — mjlab's
  own key, and the rule `entityJointIds` already applied — so the third copy of
  `decodeNames` this needed at first is gone; `decodeJointNames` already existed. A
  namespaced model with no such entity now writes nothing rather than landing on the first
  free joint. An unprefixed model is still a single-entity scene, whose one free joint is
  the entity's.
- **Velocity frame.** A root velocity write rotates its angular half into the body frame,
  as `write_root_velocity` does. Both halves arrive world-frame, but a free joint's `qvel`
  holds world-frame linear and **body**-frame angular velocity, so the value was spinning
  the body about the wrong axis for any orientation but identity. The quaternion comes from
  `qpos`, so a pose written first is the frame used — mjlab's order, and what
  `write_root_state_to_sim` splits into.
- `write_root_state_to_sim` traces, split into the same two writes mjlab splits it into.

Three things the tracer used to let through, all found while settling the above:

- An uncaptured `write_*_to_sim` was **forwarded to the live entity**, mutating the tracing
  env mid-trace and emitting no graph output — every term traced after it then read a moved
  sim. `write_root_state_to_sim` was one of these. A term walking `scene.entities` now gets
  recording stand-ins for the same reason.
- A `joint_state` term with no `asset_cfg` serialized `joint_ids: null`, which
  `resolveJointIds` dereferenced in the browser (`null` passed the `undefined`/`"all"`
  guard). It is omitted when unresolved, and tolerated on the runtime side.

**`reset_scene_to_default` no longer fails the build.** mjlab's default event restores every
entity's default root and joint state — which is what the runtime's own reset already does
(`mj_resetData` to `qpos0`, or keyframe 0) *before* any `mode="reset"` event runs. It is
emitted as a native no-op carrying that reason, through the existing
`_EVENTS_WITH_NOTHING_TO_WRITE` mechanism.

## 4. mjswan binds mjlab's velocity command itself

`UniformVelocityCommandCfg` had no mapping in mjswan: the binding lived in
`examples/mjlab/defaults/commands`, out of reach of any project that is not this repo.
`adapt_commands` warned and dropped the term, so a downstream task built on mjlab's
locomotion commands hand-wrote `velocity_command()` sliders instead — a manual `UiCommand`
that only *looks* like the real term, reading `ranges` off the very cfg mjswan declined to
adapt. It ships with mjswan now, so `add_scene_mjlab` picks the term up like any other and
`commands=` can be dropped.

The trace-friendly rewrite the binding needs lives in `mjswan.envs.mdp.commands` — mjlab
draws with `Tensor.uniform_`, which the tracer's RNG spy cannot see, and assigns through
`env_ids`, which branches on live data. It follows `events.py` in importing torch and
mjlab's math at module level, because the spy patches a term body's *module globals*.

Moving it turned up that the rewrite had fallen behind mjlab. It now carries:

- **`rel_forward_envs`** — forward-only envs, clamping the commanded speed to mjlab's 0.3
  floor and zeroing lateral and yaw. mjlab's own velocity tasks set `0.2` and `play=True`
  does not clear it, so the bundled G1 and Go1 demos were differing from mjlab one resample
  in five.
- **`rel_world_envs`** and the `vel_command_w` state it rotates, kept as the raw sample:
  mjlab copies it *before* the forward clamp, so a world+forward env rotates the unclamped
  values.
- **The `heading_command` gate.** The rewrite tracked heading unconditionally, where the
  cfg default is off.

`init_velocity_prob` is refused at build time with a message naming what it does, rather
than traced as if absent: it writes the robot's root state during resampling, gated on that
same draw.

The command parity harness cannot see any of this — `run_command_parity` traces the
*overridden* term and compares the graph against that same term, establishing
"graph == override" and never "override == mjlab". `tests/test_velocity_command.py` pins
the latter directly, building a live mjlab term against a stand-in env (no scene compiled,
so it stays out of the `slow` tier) and comparing `_update_command` across every
combination of the three per-env modes, plus the resample invariants, the guard, and that
every tensor the bodies write is declared state — an undeclared one would reset every
browser frame.

## Verification

- `pytest`: **688 passed**, parity sweep included. `vitest run`: **371 passed** across 27
  suites. `tsc --noEmit`, `eslint src/`, `ruff check` and `ruff format --check` clean.
- `tests/test_onnx_command_parity.py -k velocity`: the real `Mjlab-Velocity-Flat-Unitree-G1`
  and `-Go1` terms trace and match through the seven state fields, resolved from mjswan's
  own binding.
- The downstream path checked directly: with `examples` never imported,
  `adapt_commands(load_env_cfg("Mjlab-Velocity-Flat-Unitree-G1", play=True).commands)`
  yields an `OnnxCommand` with a pending trace and four viz primitives, no warnings. The
  control panel recorded from mjlab's own `create_gui` is its joystick — an `Enable`
  checkbox gating three axis sliders, each with a `Max` companion, and a `Zero` button.
- End to end against a live cartpole env: `reset_slider` / `reset_hinge` serialize
  `entity: "cartpole"` with entity-prefixed outputs and their own `joint_ids`, and
  `reset_scene_to_default` becomes the native no-op above with the live env's `joint_pos`
  provably untouched by tracing.
- New tests also cover: an mjlab count carrying over as a count; a group `0` switching
  history off and letting a stacking term fuse; a dense count stacking oldest-first;
  offsets still giving a newest-first stack; a subclassed mjlab group still adapted; a term
  naming its write target by a plain param; two entities each getting their own target with
  prefixed outputs; `write_root_state_to_sim` splitting; `scene.entities` walked without
  touching the live entities; an uncaptured write refused; a namespaced model with no such
  entity writing nothing; and the angular-velocity rotation, including the case where a
  pose written first supplies the frame.

## Downstream

`velocity_command()` stays — a manual control panel is still the right thing for a scene
with no mjlab task, which is what the `examples/demo` Go2, Go1 and ANYmal scenes are.

`mjswan_playground` needs no change to keep working: `husky_skater` already hand-writes
`HISTORY_STEPS = (4, 3, 2, 1, 0)`, which offsets still win with, and `wbc_g1`'s deploy
config is `actor_history_length: 1`. Two optional tidy-ups are now available there — the
`husky_skater` group can carry `history_length=5` directly, and `pacman`'s walk scene can
drop its hand-written `commands=` entirely. The latter changes that scene's feel: mjlab's
resampling command drives the robot and the operator takes over through the joystick,
where the sliders used to hold a constant forward speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ahx63d4sEQyMf6Yq1urv75
