### PR TITLE
Give the panel the controls it was missing: manual events, button commands, dr.geom_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,25 @@ shortcuts were removed outright (no alias) — see Removed.**
   observation terms read these off mjlab's `MotionCommand` as properties, which the
   tracer turns into command slots — so with the browser answering to those names, the
   task's own functions trace unmodified.
+- **`mode="manual"` event terms, fired from the control panel.** A term with this mode
+  has no schedule at all: it runs when the operator presses its button, which is the
+  whole trigger. The panel's new `Events` section draws one button per manual term and
+  one checkbox per `mode="interval"` term, the checkbox arming or disarming that term's
+  schedule — a disarmed timer stops counting rather than banking the wait, so re-arming
+  cannot fire the disturbance on the next frame. Both are also engine verbs
+  (`engine.events.fire(name)` / `engine.events.setArmed(name, armed)`), and the terms
+  they offer are reported as `MjswanEngineState.events`. `label` on the term config is
+  the text either control carries, defaulting to the term name. This is mjswan's own
+  mode, not one of mjlab's four: mjlab has a viewer to bolt a button onto and plain
+  Python state to gate a term with, where a traced graph has neither — a task that wants
+  a disturbance on demand had to settle for one on a timer. A manual term left in an
+  mjlab config is inert there, which is what a mode mjlab never applies should be.
+- **`dr.geom_size` is described for the browser**, with the broadphase bounds mjlab
+  recomputes from it: `geom_rbound` and `geom_aabb` follow the new size in the same pass,
+  by geom type (sphere, capsule, ellipsoid, cylinder, box), because a geom that grows
+  while its bound stays as compiled simply stops colliding at its own surface. A size
+  randomization on any other geom type fails the build, naming the geoms and their types;
+  mjlab raises the same refusal, but at the first firing.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,8 @@ All kept as aliases via `_compat.py`, removed in 0.9:
   mjlab task should not look like two products, so the panel now renders what mjlab's own
   viser GUI renders: command groups nested inside a `Commands` folder, one row per
   control with the label in a `5.975em` column, a slider carrying its two ends as marks
-  *and* a `3rem` number box that takes typing, the "Max" companion above the axis it
+  *and* a `3rem` number box that takes typing (at mjviser's own `1.875em` height, which
+  is what keeps a slider row the height of the checkbox row above it), the "Max" companion above the axis it
   rescales (mjlab declares it first), a checkbox in the control column rather than
   captioning itself, and a button that is full width and filled — with the icon its
   mjlab GUI asked for, `Icon.SQUARE_X` on `Zero` being the one mjlab declares today.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,14 @@ All kept as aliases via `_compat.py`, removed in 0.9:
 
 ### Fixed
 
+- **Buttons, sliders and checkboxes now match mjviser's**, control for control: the
+  slider's thumb is mjviser's bar rather than Mantine's dot (`thumbSize: 0` with a
+  `0.5rem × 0.75rem` box in the slider's own colour) on a square-cornered `xs` track, an
+  action button is `sm` at `2em` tall, and an inline one is a `compact-xs` outline. The
+  checkbox already agreed. Two viewers onto the same mjlab task should not look like two
+  products; the sizes are `em`-relative, so both panels stay identical under their own
+  root font size. The slider styling lives in the theme, so every slider in the app —
+  the splat calibration panel included — follows.
 - **The control panel draws button commands.** `button` has been a command input type
   all along, `CommandManager.triggerButton` has been wired to the term since, and
   `engine.commands.trigger` has been a verb — but the panel filtered its controls down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ shortcuts were removed outright (no alias) — see Removed.**
   Python state to gate a term with, where a traced graph has neither — a task that wants
   a disturbance on demand had to settle for one on a timer. A manual term left in an
   mjlab config is inert there, which is what a mode mjlab never applies should be.
+  `disabled_when` names the `mode="interval"` term that owns the same job: while that
+  schedule is armed the button greys out and `fire()` refuses the press, so a launcher
+  with both a timer and a button is driven by one of them at a time. The build refuses a
+  gate that names no interval term of the scene, rather than shipping a dead control.
 - **`dr.geom_size` is described for the browser**, with the broadphase bounds mjlab
   recomputes from it: `geom_rbound` and `geom_aabb` follow the new size in the same pass,
   by geom type (sphere, capsule, ellipsoid, cylinder, box), because a geom that grows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,14 +138,20 @@ All kept as aliases via `_compat.py`, removed in 0.9:
 
 ### Fixed
 
-- **Buttons, sliders and checkboxes now match mjviser's**, control for control: the
-  slider's thumb is mjviser's bar rather than Mantine's dot (`thumbSize: 0` with a
-  `0.5rem × 0.75rem` box in the slider's own colour) on a square-cornered `xs` track, an
-  action button is `sm` at `2em` tall, and an inline one is a `compact-xs` outline. The
-  checkbox already agreed. Two viewers onto the same mjlab task should not look like two
-  products; the sizes are `em`-relative, so both panels stay identical under their own
-  root font size. The slider styling lives in the theme, so every slider in the app —
-  the splat calibration panel included — follows.
+- **The control panel is mjviser's, control for control.** Two viewers onto the same
+  mjlab task should not look like two products, so the panel now renders what mjlab's own
+  viser GUI renders: command groups nested inside a `Commands` folder, one row per
+  control with the label in a `5.975em` column, a slider carrying its two ends as marks
+  *and* a `3rem` number box that takes typing, the "Max" companion above the axis it
+  rescales (mjlab declares it first), a checkbox in the control column rather than
+  captioning itself, and a button that is full width and filled — with the icon its
+  mjlab GUI asked for, `Icon.SQUARE_X` on `Zero` being the one mjlab declares today.
+  The slider's thumb is mjviser's bar rather than Mantine's dot (`thumbSize: 0` with a
+  `0.5rem × 0.75rem` box in the slider's own colour) on a square-cornered `xs` track.
+  Sizes are `em`-relative, so both panels stay identical under their own root font size,
+  and the slider styling lives in the theme, so every slider in the app — the splat
+  calibration panel included — follows. `ButtonConfig` grew an `icon`, recorded by the
+  GUI spy from the term's own `create_gui`.
 - **The control panel draws button commands.** `button` has been a command input type
   all along, `CommandManager.triggerButton` has been wired to the term since, and
   `engine.commands.trigger` has been a verb — but the panel filtered its controls down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,16 @@ All kept as aliases via `_compat.py`, removed in 0.9:
 
 ### Fixed
 
+- **The control panel draws button commands.** `button` has been a command input type
+  all along, `CommandManager.triggerButton` has been wired to the term since, and
+  `engine.commands.trigger` has been a verb — but the panel filtered its controls down
+  to sliders and checkboxes, so no button was ever drawn. mjlab's own `Zero` (declared by
+  every `UniformVelocityCommand` GUI, and recorded faithfully by the GUI spy) simply did
+  not exist for a viewer. Buttons now render in declaration order, so `Zero` lands under
+  the sliders it zeroes, and the values a press moves are re-read from the term rather
+  than left stale in the panel's mirror. `UiCommand` answers to `zero` as well, so a
+  hand-written panel gets the same button for free, and a press no term answers to warns
+  once instead of leaving a control that looks live and does nothing.
 - A position action term now inherits its PD gains from the entity's actuator configs.
   mjlab's ideal-PD family (`IdealPdActuatorCfg` and subclasses, which is what
   `wbc-mjlab`'s G1 uses) puts a `<motor>` in the model and computes

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - **Client-only**: All computation runs in the browser. No server for simulation is required.
 - **Easy Sharing**: Host as a static site for effortless demo distribution (e.g., GitHub Pages).
 - **Portable**: Embed the simulation in a web page or Google Colab notebook.
+- **mjlab-native**: Create a web demo of any [mjlab](https://github.com/mujocolab/mjlab) tasks with minimal effort.
 - **Customizable**: Visualize your mujoco models and onnx policies quickly.
 
 

--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -751,8 +751,7 @@ def model_field_dr_descriptor(
     }
 
 
-#: Geom types whose bounds follow from `geom_size`, as
-#: `dr.geom_size._recompute_geom_bounds` lists them.
+#: The geom types `dr.geom_size._recompute_geom_bounds` supports.
 _PRIMITIVE_GEOM_TYPES = frozenset(
     {
         int(mujoco.mjtGeom.mjGEOM_SPHERE),
@@ -765,10 +764,7 @@ _PRIMITIVE_GEOM_TYPES = frozenset(
 
 
 def _require_primitive_geoms(env: Any, names: list[str]) -> None:
-    """Refuse a size randomization on a geom whose bounds cannot be recomputed.
-
-    mjlab raises the same at the first firing; the build knows the types already.
-    """
+    """Refuse a size randomization on a geom whose bounds cannot be recomputed."""
     model = env.sim.mj_model
     unsupported = {
         name: mujoco.mjtGeom(int(model.geom(name).type)).name
@@ -938,8 +934,8 @@ def serialize_event(
 
 
 def _check_disabled_when(events: dict[str, EventTermCfg]) -> None:
-    """A gate naming nothing would grey a button out forever, or never — catch it here,
-    where the whole dict is in hand, rather than shipping a dead control."""
+    """Refuse a `disabled_when` naming no `mode="interval"` term: a gate that resolves to
+    nothing greys its button out forever, or never."""
     for name, term_cfg in events.items():
         gate = getattr(term_cfg, "disabled_when", None)
         if gate is None:

--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -932,7 +932,29 @@ def serialize_event(
         entry["min_step_count_between_reset"] = term_cfg.min_step_count_between_reset
     if term_cfg.label is not None:
         entry["label"] = term_cfg.label
+    if term_cfg.disabled_when is not None:
+        entry["disabled_when"] = term_cfg.disabled_when
     return entry
+
+
+def _check_disabled_when(events: dict[str, EventTermCfg]) -> None:
+    """A gate naming nothing would grey a button out forever, or never — catch it here,
+    where the whole dict is in hand, rather than shipping a dead control."""
+    for name, term_cfg in events.items():
+        gate = getattr(term_cfg, "disabled_when", None)
+        if gate is None:
+            continue
+        if term_cfg.mode != "manual":
+            raise ValueError(
+                f'Event term {name!r} is mode="{term_cfg.mode}" and carries '
+                f"disabled_when={gate!r}. Only a manual term has a button to grey out."
+            )
+        if getattr(events.get(gate), "mode", None) != "interval":
+            raise ValueError(
+                f"Event term {name!r} declares disabled_when={gate!r}, which is not a "
+                f'mode="interval" term of this scene (it has '
+                f"{sorted(n for n, t in events.items() if t.mode == 'interval')})."
+            )
 
 
 def serialize_events(
@@ -947,6 +969,7 @@ def serialize_events(
     """
     if not events:
         return None
+    _check_disabled_when(events)
     result = []
     for name, term_cfg in events.items():
         if on_term is not None:

--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -19,6 +19,8 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import mujoco
+
 from .command import ButtonConfig, CommandTermConfig
 from .envs.mdp.events import EventBinding
 from .envs.mdp.observations import ObservationBinding
@@ -728,6 +730,8 @@ def model_field_dr_descriptor(
         axis_ranges = {a: [float(ranges[0]), float(ranges[1])] for a in axes}
 
     operation = _dr_name_of(_dr_arg(func, params, "operation"), "abs")
+    if field_name == "geom_size":
+        _require_primitive_geoms(env, names)
     return {
         "kind": "model_field",
         "field": field_name,
@@ -742,7 +746,44 @@ def model_field_dr_descriptor(
         # they never accumulate across events on one axis.
         "uses_defaults": operation in _DR_OPS_USING_DEFAULTS,
         "set_const": _dr_needs_recompute(func, field_name),
+        # `geom_size` feeds the broadphase, which mjlab recomputes from it in the same
+        # call; the browser owes the same afterwards.
+        "recompute_bounds": field_name == "geom_size",
     }
+
+
+#: Geom types whose `rbound`/`aabb` follow from `geom_size` — mjlab's own list in
+#: `dr.geom_size._recompute_geom_bounds`, and the browser reproduces its arithmetic.
+_PRIMITIVE_GEOM_TYPES = frozenset(
+    {
+        int(mujoco.mjtGeom.mjGEOM_SPHERE),
+        int(mujoco.mjtGeom.mjGEOM_CAPSULE),
+        int(mujoco.mjtGeom.mjGEOM_ELLIPSOID),
+        int(mujoco.mjtGeom.mjGEOM_CYLINDER),
+        int(mujoco.mjtGeom.mjGEOM_BOX),
+    }
+)
+
+
+def _require_primitive_geoms(env: Any, names: list[str]) -> None:
+    """Refuse a size randomization on a geom whose bounds cannot be recomputed.
+
+    mjlab raises the same refusal at runtime, once the event fires; the build knows the
+    geom types, so it raises before the bundle exists.
+    """
+    model = env.sim.mj_model
+    unsupported = {
+        name: mujoco.mjtGeom(int(model.geom(name).type)).name
+        for name in names
+        if int(model.geom(name).type) not in _PRIMITIVE_GEOM_TYPES
+    }
+    if unsupported:
+        raise ValueError(
+            "dr.geom_size only supports primitive geom types (sphere, capsule, "
+            f"ellipsoid, cylinder, box); these are not: {unsupported}. mjlab raises "
+            "the same, because the broadphase bounds it recomputes from the size are "
+            "only defined for those."
+        )
 
 
 # mjlab's `Operation.uses_defaults`: `abs` reads the live value, `add`/`scale` the default.
@@ -770,6 +811,7 @@ def _dr_needs_recompute(func: Any, field_name: str) -> bool:
 # nothing can introspect them. An author's own wrapper can set `_mjswan_dr_field`.
 _DR_FIELD_BY_FUNC: dict[str, tuple[str, str, list[int]]] = {
     "geom_friction": ("geom_friction", "geom", [0]),
+    "geom_size": ("geom_size", "geom", [0, 1, 2]),
     "geom_rgba": ("geom_rgba", "geom", [0, 1, 2, 3]),
     "body_com_offset": ("body_ipos", "body", [0, 1, 2]),
     "body_ipos": ("body_ipos", "body", [0, 1, 2]),
@@ -825,6 +867,14 @@ def serialize_event(
     name: str, term_cfg: EventTermCfg, env: Any, out_dir: Path
 ) -> dict[str, Any] | None:
     """Serialize one event term, or ``None`` if there is genuinely nothing to emit."""
+    # Before the torch import below: a config mistake should not need a tracer to report.
+    if term_cfg.mode == "manual" and term_cfg.interval_range_s is not None:
+        raise ValueError(
+            f'Event term {name!r} is mode="manual" and carries '
+            f"interval_range_s={term_cfg.interval_range_s!r}. A manual term has no "
+            "schedule — the operator's button is its only trigger. Declare a second "
+            'mode="interval" term if it should also fire on its own.'
+        )
     from .compile import trace_event_term
     from .compile.tracer import slots_json
 
@@ -882,6 +932,8 @@ def serialize_event(
         entry["is_global_time"] = term_cfg.is_global_time
     if term_cfg.mode == "reset" and term_cfg.min_step_count_between_reset:
         entry["min_step_count_between_reset"] = term_cfg.min_step_count_between_reset
+    if term_cfg.label is not None:
+        entry["label"] = term_cfg.label
     return entry
 
 

--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -746,14 +746,13 @@ def model_field_dr_descriptor(
         # they never accumulate across events on one axis.
         "uses_defaults": operation in _DR_OPS_USING_DEFAULTS,
         "set_const": _dr_needs_recompute(func, field_name),
-        # `geom_size` feeds the broadphase, which mjlab recomputes from it in the same
-        # call; the browser owes the same afterwards.
+        # mjlab recomputes the broadphase bounds from the size in the same call.
         "recompute_bounds": field_name == "geom_size",
     }
 
 
-#: Geom types whose `rbound`/`aabb` follow from `geom_size` — mjlab's own list in
-#: `dr.geom_size._recompute_geom_bounds`, and the browser reproduces its arithmetic.
+#: Geom types whose bounds follow from `geom_size`, as
+#: `dr.geom_size._recompute_geom_bounds` lists them.
 _PRIMITIVE_GEOM_TYPES = frozenset(
     {
         int(mujoco.mjtGeom.mjGEOM_SPHERE),
@@ -768,8 +767,7 @@ _PRIMITIVE_GEOM_TYPES = frozenset(
 def _require_primitive_geoms(env: Any, names: list[str]) -> None:
     """Refuse a size randomization on a geom whose bounds cannot be recomputed.
 
-    mjlab raises the same refusal at runtime, once the event fires; the build knows the
-    geom types, so it raises before the bundle exists.
+    mjlab raises the same at the first firing; the build knows the types already.
     """
     model = env.sim.mj_model
     unsupported = {

--- a/src/mjswan/adapters/gui_spy.py
+++ b/src/mjswan/adapters/gui_spy.py
@@ -26,6 +26,7 @@ class _Handle:
     min: float | None = None
     max: float | None = None
     step: float | None = None
+    icon: str | None = None
 
     def on_update(self, fn: Any) -> Any:
         return fn
@@ -84,8 +85,11 @@ class _GuiRecorder:
             _Handle("slider", label, value=initial_value, min=min, max=max, step=step)
         )
 
-    def add_button(self, label: str, **_: Any) -> _Handle:
-        return self._record(_Handle("button", label))
+    def add_button(self, label: str, icon: Any = None, **_: Any) -> _Handle:
+        # viser's `Icon` members are plain tabler names (`Icon.SQUARE_X` == "square-x").
+        return self._record(
+            _Handle("button", label, icon=str(icon) if icon is not None else None)
+        )
 
 
 @dataclass
@@ -151,9 +155,14 @@ def to_ui_descriptor(handles: list[_Handle]) -> dict[str, Any] | None:
                 companion = None
             inputs.append(entry)
         elif handle.kind == "button":
-            inputs.append(
-                {"type": "button", "name": _slug(handle.label), "label": handle.label}
-            )
+            entry = {
+                "type": "button",
+                "name": _slug(handle.label),
+                "label": handle.label,
+            }
+            if handle.icon is not None:
+                entry["icon"] = handle.icon
+            inputs.append(entry)
 
     return {"inputs": inputs} if inputs else None
 

--- a/src/mjswan/command.py
+++ b/src/mjswan/command.py
@@ -115,8 +115,8 @@ class ButtonConfig:
     name: str
     label: str
     icon: str | None = None
-    """Tabler icon name, as viser's ``Icon`` enum spells it (``Icon.SQUARE_X`` is
-    ``"square-x"``). The browser draws the ones it bundles and ignores the rest."""
+    """Tabler icon name, as viser's ``Icon`` spells it (``Icon.SQUARE_X`` is
+    ``"square-x"``). The browser draws the ones it bundles."""
 
     def to_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {

--- a/src/mjswan/command.py
+++ b/src/mjswan/command.py
@@ -116,7 +116,7 @@ class ButtonConfig:
     label: str
     icon: str | None = None
     """Tabler icon name, as viser's ``Icon`` spells it (``Icon.SQUARE_X`` is
-    ``"square-x"``). The browser draws the ones it bundles."""
+    ``"square-x"``); the browser draws only the ones it bundles."""
 
     def to_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {

--- a/src/mjswan/command.py
+++ b/src/mjswan/command.py
@@ -114,13 +114,19 @@ class ButtonConfig:
 
     name: str
     label: str
+    icon: str | None = None
+    """Tabler icon name, as viser's ``Icon`` enum spells it (``Icon.SQUARE_X`` is
+    ``"square-x"``). The browser draws the ones it bundles and ignores the rest."""
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        data: dict[str, Any] = {
             "type": "button",
             "name": self.name,
             "label": self.label,
         }
+        if self.icon is not None:
+            data["icon"] = self.icon
+        return data
 
 
 Button = ButtonConfig

--- a/src/mjswan/managers/event_manager.py
+++ b/src/mjswan/managers/event_manager.py
@@ -2,8 +2,7 @@
 
 Provides ``EventTermCfg`` for scene-level events: ``reset``, ``interval``
 (e.g. periodic disturbances), ``startup`` (e.g. domain randomization run
-once at load) — ADR 0005 §4 — and ``manual``, which fires only when the
-operator asks, from a button in the control panel.
+once at load) — ADR 0005 §4 — and ``manual``, fired from the control panel.
 """
 
 from __future__ import annotations
@@ -32,12 +31,8 @@ class EventTermCfg:
 
     mode: EventMode = "reset"
     """Event trigger mode: ``reset``, ``interval``, ``startup`` (ADR 0005 §4/§5), or
-    ``manual`` — no schedule at all, fired from the control panel's own button.
-
-    ``manual`` is mjswan's, not mjlab's: mjlab has a viewer to bolt a button onto and
-    plain Python state to gate a term with, while a traced graph has neither. A term
-    left in an mjlab config with this mode is inert there, which is what a mode mjlab's
-    ``EventManager`` never applies should be."""
+    ``manual`` — no schedule at all, fired from the control panel's button. ``manual`` is
+    mjswan's own, and inert in an mjlab config: mjlab never applies that mode."""
 
     params: dict[str, Any] = field(default_factory=dict)
     """Parameters forwarded to the TS event constructor or traced function."""
@@ -52,8 +47,8 @@ class EventTermCfg:
     """``mode="reset"`` only: suppress firing on resets that arrive too soon."""
 
     label: str | None = None
-    """Control-panel text for this term: a ``manual`` term's button, an ``interval``
-    term's arm checkbox. Defaults browser-side to the term name."""
+    """Control-panel text — a ``manual`` term's button, an ``interval`` term's arm
+    checkbox. Defaults browser-side to the term name."""
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize an ``EventBinding`` term.

--- a/src/mjswan/managers/event_manager.py
+++ b/src/mjswan/managers/event_manager.py
@@ -2,7 +2,7 @@
 
 Provides ``EventTermCfg`` for scene-level events: ``reset``, ``interval``
 (e.g. periodic disturbances), ``startup`` (e.g. domain randomization run
-once at load) — ADR 0005 §4 — and ``manual``, fired from the control panel.
+once at load), and ``manual``, fired from the control panel.
 """
 
 from __future__ import annotations
@@ -30,9 +30,9 @@ class EventTermCfg:
     """Event function — EventBinding sentinel (legacy) or a traceable mjlab-style body."""
 
     mode: EventMode = "reset"
-    """Event trigger mode: ``reset``, ``interval``, ``startup`` (ADR 0005 §4/§5), or
-    ``manual`` — no schedule, the control panel's button is the whole trigger. ``manual``
-    is mjswan's own: an mjlab config carrying one is inert there."""
+    """Event trigger mode: ``reset``, ``interval``, ``startup``, or ``manual`` — no
+    schedule, the control panel's button is the whole trigger. ``manual`` is mjswan's
+    own: an mjlab config carrying one is inert there."""
 
     params: dict[str, Any] = field(default_factory=dict)
     """Parameters forwarded to the TS event constructor or traced function."""

--- a/src/mjswan/managers/event_manager.py
+++ b/src/mjswan/managers/event_manager.py
@@ -1,8 +1,9 @@
 """Event manager configuration for mjswan.
 
 Provides ``EventTermCfg`` for scene-level events: ``reset``, ``interval``
-(e.g. periodic disturbances), and ``startup`` (e.g. domain randomization run
-once at load) — ADR 0005 §4.
+(e.g. periodic disturbances), ``startup`` (e.g. domain randomization run
+once at load) — ADR 0005 §4 — and ``manual``, which fires only when the
+operator asks, from a button in the control panel.
 """
 
 from __future__ import annotations
@@ -12,7 +13,7 @@ from typing import Any, Callable, Literal
 
 from ..envs.mdp.events import EventBinding
 
-EventMode = Literal["reset", "interval", "startup"]
+EventMode = Literal["reset", "interval", "startup", "manual"]
 
 
 @dataclass
@@ -30,7 +31,13 @@ class EventTermCfg:
     """Event function — EventBinding sentinel (legacy) or a traceable mjlab-style body."""
 
     mode: EventMode = "reset"
-    """Event trigger mode: ``reset``, ``interval``, or ``startup`` (ADR 0005 §4/§5)."""
+    """Event trigger mode: ``reset``, ``interval``, ``startup`` (ADR 0005 §4/§5), or
+    ``manual`` — no schedule at all, fired from the control panel's own button.
+
+    ``manual`` is mjswan's, not mjlab's: mjlab has a viewer to bolt a button onto and
+    plain Python state to gate a term with, while a traced graph has neither. A term
+    left in an mjlab config with this mode is inert there, which is what a mode mjlab's
+    ``EventManager`` never applies should be."""
 
     params: dict[str, Any] = field(default_factory=dict)
     """Parameters forwarded to the TS event constructor or traced function."""
@@ -43,6 +50,10 @@ class EventTermCfg:
 
     min_step_count_between_reset: int | None = None
     """``mode="reset"`` only: suppress firing on resets that arrive too soon."""
+
+    label: str | None = None
+    """Control-panel text for this term: a ``manual`` term's button, an ``interval``
+    term's arm checkbox. Defaults browser-side to the term name."""
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize an ``EventBinding`` term.

--- a/src/mjswan/managers/event_manager.py
+++ b/src/mjswan/managers/event_manager.py
@@ -31,8 +31,8 @@ class EventTermCfg:
 
     mode: EventMode = "reset"
     """Event trigger mode: ``reset``, ``interval``, ``startup`` (ADR 0005 §4/§5), or
-    ``manual`` — no schedule at all, fired from the control panel's button. ``manual`` is
-    mjswan's own, and inert in an mjlab config: mjlab never applies that mode."""
+    ``manual`` — no schedule, the control panel's button is the whole trigger. ``manual``
+    is mjswan's own: an mjlab config carrying one is inert there."""
 
     params: dict[str, Any] = field(default_factory=dict)
     """Parameters forwarded to the TS event constructor or traced function."""

--- a/src/mjswan/managers/event_manager.py
+++ b/src/mjswan/managers/event_manager.py
@@ -50,6 +50,10 @@ class EventTermCfg:
     """Control-panel text — a ``manual`` term's button, an ``interval`` term's arm
     checkbox. Defaults browser-side to the term name."""
 
+    disabled_when: str | None = None
+    """``mode="manual"`` only: the ``mode="interval"`` term that owns the same job. The
+    button greys out, and refuses to fire, while that term's schedule is armed."""
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize an ``EventBinding`` term.
 

--- a/src/mjswan/template/package-lock.json
+++ b/src/mjswan/template/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mjswan",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mjswan",
-      "version": "0.9.0",
+      "version": "0.9.2",
       "dependencies": {
         "@mantine/core": "^8.3.0",
         "@mantine/hooks": "^8.3.0",

--- a/src/mjswan/template/package-lock.json
+++ b/src/mjswan/template/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mjswan",
-  "version": "0.9.2",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mjswan",
-      "version": "0.9.2",
+      "version": "0.9.0",
       "dependencies": {
         "@mantine/core": "^8.3.0",
         "@mantine/hooks": "^8.3.0",

--- a/src/mjswan/template/src/App.tsx
+++ b/src/mjswan/template/src/App.tsx
@@ -356,6 +356,7 @@ function AppContent() {
             commands={engineState?.commands ? [...engineState.commands] : []}
             commandValues={engineState?.commandValues ?? {}}
             onCommandChange={(id, value) => engineRef.current?.commands.set(id, value)}
+            onCommandTrigger={(id) => engineRef.current?.commands.trigger(id)}
             events={engineState?.events ? [...engineState.events] : []}
             onEventFire={(name) => engineRef.current?.events.fire(name)}
             onEventArmedChange={(name, armed) => engineRef.current?.events.setArmed(name, armed)}

--- a/src/mjswan/template/src/App.tsx
+++ b/src/mjswan/template/src/App.tsx
@@ -356,6 +356,9 @@ function AppContent() {
             commands={engineState?.commands ? [...engineState.commands] : []}
             commandValues={engineState?.commandValues ?? {}}
             onCommandChange={(id, value) => engineRef.current?.commands.set(id, value)}
+            events={engineState?.events ? [...engineState.events] : []}
+            onEventFire={(name) => engineRef.current?.events.fire(name)}
+            onEventArmedChange={(name, armed) => engineRef.current?.events.setArmed(name, armed)}
             debugVis={engineState?.debugVis ? [...engineState.debugVis] : []}
             onDebugVisChange={(term, enabled) => engineRef.current?.debugVis.set(term, enabled)}
             onReset={() => engineRef.current?.reset()}

--- a/src/mjswan/template/src/AppTheme.ts
+++ b/src/mjswan/template/src/AppTheme.ts
@@ -46,9 +46,8 @@ export const theme = createTheme({
       defaultProps: {
         radius: "xs",
         styles: {
-          // mjviser's own box: `1.875em` tall against its own `xs` type, which is what
-          // keeps a slider row the same height as the checkbox row above it. Mantine's
-          // `xs` input is a third taller and sets every row's rhythm from the box.
+          // mjviser's own box, and the height of a slider row: Mantine's `xs` input is
+          // a third taller, and a row is as tall as its tallest child.
           input: {
             height: "1.875em",
             minHeight: "1.875em",
@@ -81,9 +80,8 @@ export const theme = createTheme({
         },
       },
     }),
-    // mjviser's slider, prop for prop: a thin `xs` track with square corners and a
-    // thumb that is a *bar* rather than a dot — `thumbSize: 0` collapses Mantine's
-    // circle so the box below is the whole shape.
+    // mjviser's slider: a thin `xs` track with square corners, and a thumb that is a
+    // bar — `thumbSize: 0` collapses Mantine's circle so the box below is the shape.
     Slider: Slider.extend({
       defaultProps: {
         size: "xs",
@@ -99,8 +97,7 @@ export const theme = createTheme({
             height: "0.75rem",
             background: "var(--slider-color)",
           },
-          // The ends of the range, marked and labelled under the track as mjviser
-          // does. `index.css` tucks the two labels inside the track's ends.
+          // The range's ends, marked under the track; `index.css` tucks their labels in.
           mark: {
             transform: "scale(2)",
           },

--- a/src/mjswan/template/src/AppTheme.ts
+++ b/src/mjswan/template/src/AppTheme.ts
@@ -2,6 +2,7 @@ import {
   Checkbox,
   ColorInput,
   Select,
+  Slider,
   TextInput,
   NumberInput,
   Paper,
@@ -65,6 +66,27 @@ export const theme = createTheme({
         styles: {
           label: {
             fontWeight: 450,
+          },
+        },
+      },
+    }),
+    // mjviser's slider, prop for prop: a thin `xs` track with square corners and a
+    // thumb that is a *bar* rather than a dot — `thumbSize: 0` collapses Mantine's
+    // circle so the box below is the whole shape.
+    Slider: Slider.extend({
+      defaultProps: {
+        size: "xs",
+        radius: "xs",
+        thumbSize: 0,
+        styles: {
+          root: {
+            paddingTop: "0.3em",
+            paddingBottom: "0.2em",
+          },
+          thumb: {
+            width: "0.5rem",
+            height: "0.75rem",
+            background: "var(--slider-color)",
           },
         },
       },

--- a/src/mjswan/template/src/AppTheme.ts
+++ b/src/mjswan/template/src/AppTheme.ts
@@ -45,6 +45,17 @@ export const theme = createTheme({
     NumberInput: NumberInput.extend({
       defaultProps: {
         radius: "xs",
+        styles: {
+          // mjviser's own box: `1.875em` tall against its own `xs` type, which is what
+          // keeps a slider row the same height as the checkbox row above it. Mantine's
+          // `xs` input is a third taller and sets every row's rhythm from the box.
+          input: {
+            height: "1.875em",
+            minHeight: "1.875em",
+            padding: "0.375em",
+            letterSpacing: "-0.5px",
+          },
+        },
       },
     }),
     Paper: Paper.extend({

--- a/src/mjswan/template/src/AppTheme.ts
+++ b/src/mjswan/template/src/AppTheme.ts
@@ -88,6 +88,16 @@ export const theme = createTheme({
             height: "0.75rem",
             background: "var(--slider-color)",
           },
+          // The ends of the range, marked and labelled under the track as mjviser
+          // does. `index.css` tucks the two labels inside the track's ends.
+          mark: {
+            transform: "scale(2)",
+          },
+          markLabel: {
+            fontSize: "0.6rem",
+            transform: "translate(-50%, 0.05rem)",
+            textAlign: "center",
+          },
         },
       },
     }),

--- a/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
+++ b/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
@@ -20,10 +20,7 @@ import {
 import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconRefresh, IconSquareX, IconX } from '@tabler/icons-react';
 
-/**
- * Icons an mjlab command GUI can ask for, by tabler name (`Icon.SQUARE_X` is
- * `"square-x"`). Only these are bundled; anything else renders without an icon.
- */
+/** Icons an mjlab GUI can ask for; the rest of tabler is unbundled, so goes undrawn. */
 const COMMAND_BUTTON_ICONS: Record<string, typeof IconSquareX> = {
   'square-x': IconSquareX,
 };
@@ -118,7 +115,7 @@ function formatGroupName(groupName: string): string {
     .join(' ');
 }
 
-/** The bound as printed under the track end: the number, without float noise. */
+/** The bound as printed under a track end, without float noise. */
 function formatBound(value: number): string {
   return String(Number(value.toFixed(3)));
 }
@@ -720,8 +717,8 @@ function ControlPanel(props: ControlPanelProps) {
             </CommandSection>
           )}
 
-          {/* Events: a button fires one, a checkbox lets its schedule run. Scene-level,
-              so no policy is needed to drive them. */}
+          {/* Events: a button fires one, a checkbox lets its schedule run — scene-level,
+              so no policy has to be loaded for either. */}
           {events.length > 0 && (
             <CommandSection label="Events" expandByDefault={true}>
               {events

--- a/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
+++ b/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
@@ -66,6 +66,8 @@ interface ControlPanelProps {
   commandValues: Record<string, number>;
   /** Write a slider/checkbox command value (engine.commands.set). */
   onCommandChange: (id: string, value: number) => void;
+  /** Press a button command (engine.commands.trigger) — mjlab's `Zero`, and any other. */
+  onCommandTrigger?: (id: string) => void;
   /** Event terms the operator can drive: manual buttons, interval schedules. */
   events?: EventDescriptor[];
   /** Fire a `mode="manual"` event term (engine.events.fire). */
@@ -277,6 +279,7 @@ function ControlPanel(props: ControlPanelProps) {
     commands,
     commandValues,
     onCommandChange,
+    onCommandTrigger,
     events = [],
     onEventFire,
     onEventArmedChange,
@@ -350,9 +353,12 @@ function ControlPanel(props: ControlPanelProps) {
     };
   }, [visible, onVisibleChange, handleReset]);
 
-  const getValueCommandsForGroup = (groupName: string): CommandDescriptor[] => {
+  const getCommandsForGroup = (groupName: string): CommandDescriptor[] => {
+    // Declaration order, so a `Zero` button lands under the sliders it zeroes.
     return commands.filter(
-      (cmd) => cmd.group === groupName && (cmd.type === 'slider' || cmd.type === 'checkbox')
+      (cmd) =>
+        cmd.group === groupName &&
+        (cmd.type === 'slider' || cmd.type === 'checkbox' || cmd.type === 'button')
     );
   };
 
@@ -630,10 +636,10 @@ function ControlPanel(props: ControlPanelProps) {
           )}
 
           {/* Command Groups - only show if there are commands */}
-          {commandGroups.length > 0 && commands.some(cmd => cmd.type === 'slider' || cmd.type === 'checkbox') && (
+          {commandGroups.length > 0 && commands.some(cmd => cmd.type === 'slider' || cmd.type === 'checkbox' || cmd.type === 'button') && (
             <>
               {commandGroups.map((groupName) => {
-                const groupCommands = getValueCommandsForGroup(groupName);
+                const groupCommands = getCommandsForGroup(groupName);
                 if (groupCommands.length === 0) return null;
 
                 return (
@@ -652,6 +658,21 @@ function ControlPanel(props: ControlPanelProps) {
                             onChange={onCommandChange}
                             disabled={!commandsEnabled}
                           />
+                        );
+                      }
+                      if (command.type === 'button') {
+                        return (
+                          <Box key={command.id} px="xs" pb="0.375em">
+                            <Button
+                              size="compact-xs"
+                              variant="light"
+                              radius="xs"
+                              onClick={() => onCommandTrigger?.(command.id)}
+                              disabled={!commandsEnabled || !onCommandTrigger}
+                            >
+                              {command.label}
+                            </Button>
+                          </Box>
                         );
                       }
                       if (command.type !== 'slider') {

--- a/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
+++ b/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
@@ -173,13 +173,7 @@ function SliderControl({
             min={min}
             max={max}
             step={command.step}
-            size="xs"
             disabled={isDisabled}
-            styles={{
-              root: { padding: '0' },
-              track: { height: 4 },
-              thumb: { width: 12, height: 12 },
-            }}
           />
         </Box>
       </Box>
@@ -210,13 +204,7 @@ function SliderControl({
               min={range.min}
               max={range.max}
               step={range.step}
-              size="xs"
               disabled={isDisabled}
-              styles={{
-                root: { padding: '0' },
-                track: { height: 3 },
-                thumb: { width: 10, height: 10 },
-              }}
             />
           </Box>
         </Box>
@@ -662,16 +650,25 @@ function ControlPanel(props: ControlPanelProps) {
                       }
                       if (command.type === 'button') {
                         return (
-                          <Box key={command.id} px="xs" pb="0.375em">
-                            <Button
-                              size="compact-xs"
-                              variant="light"
-                              radius="xs"
-                              onClick={() => onCommandTrigger?.(command.id)}
-                              disabled={!commandsEnabled || !onCommandTrigger}
-                            >
-                              {command.label}
-                            </Button>
+                          <Box
+                            key={command.id}
+                            px="xs"
+                            pb="0.5em"
+                            style={{ display: 'flex', alignItems: 'center' }}
+                          >
+                            {/* The label column stays empty, so the button lines up
+                                under the controls it acts on, as mjviser's do. */}
+                            <Box style={{ width: '50%', flexShrink: 0 }} />
+                            <Box style={{ width: '50%' }}>
+                              <Button
+                                size="compact-xs"
+                                variant="outline"
+                                onClick={() => onCommandTrigger?.(command.id)}
+                                disabled={!commandsEnabled || !onCommandTrigger}
+                              >
+                                {command.label}
+                              </Button>
+                            </Box>
                           </Box>
                         );
                       }
@@ -703,24 +700,21 @@ function ControlPanel(props: ControlPanelProps) {
               let its schedule run. Scene-level, so no policy is needed to drive them. */}
           {events.length > 0 && (
             <CommandSection label="Events" expandByDefault={true}>
-              {events.filter((event) => event.kind === 'manual').length > 0 && (
-                <Box px="xs" pb="0.375em" style={{ display: 'flex', flexWrap: 'wrap', gap: '0.375em' }}>
-                  {events
-                    .filter((event) => event.kind === 'manual')
-                    .map((event) => (
-                      <Button
-                        key={event.name}
-                        size="compact-xs"
-                        variant="light"
-                        radius="xs"
-                        onClick={() => onEventFire?.(event.name)}
-                        disabled={!onEventFire}
-                      >
-                        {event.label}
-                      </Button>
-                    ))}
-                </Box>
-              )}
+              {events
+                .filter((event) => event.kind === 'manual')
+                .map((event) => (
+                  <Box key={event.name} px="xs" pb="0.5em">
+                    <Button
+                      size="sm"
+                      fullWidth
+                      style={{ height: '2em' }}
+                      onClick={() => onEventFire?.(event.name)}
+                      disabled={!onEventFire}
+                    >
+                      {event.label}
+                    </Button>
+                  </Box>
+                ))}
               {events
                 .filter((event) => event.kind === 'interval')
                 .map((event) => (
@@ -762,8 +756,9 @@ function ControlPanel(props: ControlPanelProps) {
             <Button
               variant="light"
               color="red"
-              size="xs"
+              size="sm"
               fullWidth
+              style={{ height: '2em' }}
               leftSection={<IconRefresh size={14} />}
               onClick={handleReset}
             >

--- a/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
+++ b/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
@@ -6,9 +6,11 @@ import {
   Button,
   Checkbox,
   Divider,
+  Flex,
   Image,
   Menu,
   Modal,
+  NumberInput,
   Select,
   Slider,
   Stack,
@@ -16,7 +18,17 @@ import {
   Tooltip,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconChevronDown, IconRefresh, IconX } from '@tabler/icons-react';
+import { IconChevronDown, IconRefresh, IconSquareX, IconX } from '@tabler/icons-react';
+
+/**
+ * Icons an mjlab command GUI can ask for, by the tabler name viser's `Icon` enum spells
+ * (`Icon.SQUARE_X` is the string `"square-x"`). Only the ones mjlab actually declares are
+ * bundled; anything else renders as a button with no icon rather than pulling the whole
+ * icon set into the app.
+ */
+const COMMAND_BUTTON_ICONS: Record<string, typeof IconSquareX> = {
+  'square-x': IconSquareX,
+};
 import type { SplatConfig } from '../core/scene/splat';
 import { MJSWAN_VERSION, GITHUB_CONTRIBUTORS, type Contributor } from '../Version';
 import FloatingPanel from './FloatingPanel';
@@ -108,8 +120,76 @@ function formatGroupName(groupName: string): string {
     .join(' ');
 }
 
+/** A bound as mjviser prints it under the track end: the number, without float noise. */
+function formatBound(value: number): string {
+  return String(Number(value.toFixed(3)));
+}
+
 /**
- * SliderControl - Renders a slider for a slider command with horizontal layout
+ * One slider row, in mjviser's layout: the label, the track with its two ends marked,
+ * and the value in a box that also takes typing.
+ */
+function SliderRow({
+  id,
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  disabled,
+}: {
+  id: string;
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  /** A slider descriptor always carries one; Mantine's own default stands in if not. */
+  step?: number;
+  onChange: (value: number) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <LabeledInput id={id} label={label}>
+      <Flex justify="space-between">
+        <Slider
+          id={id}
+          value={value}
+          onChange={onChange}
+          min={min}
+          max={max}
+          step={step}
+          disabled={disabled}
+          marks={[
+            { value: min, label: formatBound(min) },
+            { value: max, label: formatBound(max) },
+          ]}
+          style={{ flexGrow: 1 }}
+        />
+        <NumberInput
+          value={value}
+          onChange={(next) => {
+            const parsed = typeof next === 'number' ? next : Number(next);
+            if (Number.isFinite(parsed)) onChange(parsed);
+          }}
+          min={min}
+          max={max}
+          step={step}
+          size="xs"
+          hideControls
+          clampBehavior="strict"
+          decimalScale={3}
+          disabled={disabled}
+          style={{ width: '3rem', marginLeft: 'var(--mantine-spacing-xs)' }}
+        />
+      </Flex>
+    </LabeledInput>
+  );
+}
+
+/**
+ * SliderControl - one command's slider, preceded by its "Max" companion when the build
+ * asked for one, which is the order mjlab's own GUI declares them in.
  */
 function SliderControl({
   command,
@@ -132,8 +212,9 @@ function SliderControl({
   // never sent to the engine, matching mjlab's play GUI. Symmetric around zero.
   const range = command.adjustableRange;
   const [reach, setReach] = useState(range?.default ?? 0);
-  const min = range ? -reach : command.min;
-  const max = range ? reach : command.max;
+  // `min`/`max` are declared optional because they are slider-only; a slider has them.
+  const min = range ? -reach : (command.min ?? 0);
+  const max = range ? reach : (command.max ?? 1);
 
   // Narrowing the reach past the current value would leave the thumb outside the
   // track, so bring the command with it rather than showing a stale position.
@@ -145,70 +226,28 @@ function SliderControl({
 
   return (
     <>
-      <Box
-        pb="0.5em"
-        px="xs"
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-        }}
-      >
-        <Text
-          c="dimmed"
-          style={{
-            fontSize: '0.875em',
-            fontWeight: 450,
-            lineHeight: '1.375em',
-            letterSpacing: '-0.75px',
-            width: '50%',
-            flexShrink: 0,
-          }}
-        >
-          {command.label}
-        </Text>
-        <Box style={{ width: '50%' }}>
-          <Slider
-            value={value}
-            onChange={(val) => onChange(command.id, val)}
-            min={min}
-            max={max}
-            step={command.step}
-            disabled={isDisabled}
-          />
-        </Box>
-      </Box>
       {range && (
-        <Box
-          pb="0.5em"
-          px="xs"
-          style={{ display: 'flex', alignItems: 'center' }}
-        >
-          <Text
-            c="dimmed"
-            style={{
-              fontSize: '0.75em',
-              fontWeight: 400,
-              lineHeight: '1.375em',
-              letterSpacing: '-0.75px',
-              width: '50%',
-              flexShrink: 0,
-              opacity: 0.75,
-            }}
-          >
-            {range.label ?? `Max ${command.label}`}
-          </Text>
-          <Box style={{ width: '50%' }}>
-            <Slider
-              value={reach}
-              onChange={setReach}
-              min={range.min}
-              max={range.max}
-              step={range.step}
-              disabled={isDisabled}
-            />
-          </Box>
-        </Box>
+        <SliderRow
+          id={`${command.id}:max`}
+          label={range.label ?? `Max ${command.label}`}
+          value={reach}
+          min={range.min}
+          max={range.max}
+          step={range.step}
+          onChange={setReach}
+          disabled={isDisabled}
+        />
       )}
+      <SliderRow
+        id={command.id}
+        label={command.label}
+        value={value}
+        min={min}
+        max={max}
+        step={command.step}
+        onChange={(next) => onChange(command.id, next)}
+        disabled={isDisabled}
+      />
     </>
   );
 }
@@ -225,15 +264,15 @@ function CheckboxControl({
   disabled?: boolean;
 }) {
   return (
-    <Box pb="0.5em" px="xs">
+    <LabeledInput id={command.id} label={command.label}>
       <Checkbox
-        label={command.label}
+        id={command.id}
         checked={value >= 0.5}
         onChange={(event) => onChange(command.id, event.currentTarget.checked ? 1.0 : 0.0)}
         size="xs"
         disabled={disabled}
       />
-    </Box>
+    </LabeledInput>
   );
 }
 
@@ -625,7 +664,7 @@ function ControlPanel(props: ControlPanelProps) {
 
           {/* Command Groups - only show if there are commands */}
           {commandGroups.length > 0 && commands.some(cmd => cmd.type === 'slider' || cmd.type === 'checkbox' || cmd.type === 'button') && (
-            <>
+            <CommandSection label="Commands" expandByDefault={true}>
               {commandGroups.map((groupName) => {
                 const groupCommands = getCommandsForGroup(groupName);
                 if (groupCommands.length === 0) return null;
@@ -649,26 +688,19 @@ function ControlPanel(props: ControlPanelProps) {
                         );
                       }
                       if (command.type === 'button') {
+                        const Icon = command.icon ? COMMAND_BUTTON_ICONS[command.icon] : undefined;
                         return (
-                          <Box
-                            key={command.id}
-                            px="xs"
-                            pb="0.5em"
-                            style={{ display: 'flex', alignItems: 'center' }}
-                          >
-                            {/* The label column stays empty, so the button lines up
-                                under the controls it acts on, as mjviser's do. */}
-                            <Box style={{ width: '50%', flexShrink: 0 }} />
-                            <Box style={{ width: '50%' }}>
-                              <Button
-                                size="compact-xs"
-                                variant="outline"
-                                onClick={() => onCommandTrigger?.(command.id)}
-                                disabled={!commandsEnabled || !onCommandTrigger}
-                              >
-                                {command.label}
-                              </Button>
-                            </Box>
+                          <Box key={command.id} px="xs" pb="0.5em">
+                            <Button
+                              size="sm"
+                              fullWidth
+                              style={{ height: '2em' }}
+                              leftSection={Icon ? <Icon size="1em" /> : undefined}
+                              onClick={() => onCommandTrigger?.(command.id)}
+                              disabled={!commandsEnabled || !onCommandTrigger}
+                            >
+                              {command.label}
+                            </Button>
                           </Box>
                         );
                       }
@@ -693,7 +725,7 @@ function ControlPanel(props: ControlPanelProps) {
                   </CommandSection>
                 );
               })}
-            </>
+            </CommandSection>
           )}
 
           {/* Events — the scene's disturbances: a button to fire one, a checkbox to
@@ -718,9 +750,9 @@ function ControlPanel(props: ControlPanelProps) {
               {events
                 .filter((event) => event.kind === 'interval')
                 .map((event) => (
-                  <Box key={event.name} px="xs" pb="0.375em">
+                  <LabeledInput key={event.name} id={`event:${event.name}`} label={event.label}>
                     <Checkbox
-                      label={event.label}
+                      id={`event:${event.name}`}
                       checked={event.armed}
                       onChange={(changed) =>
                         onEventArmedChange?.(event.name, changed.currentTarget.checked)
@@ -728,7 +760,7 @@ function ControlPanel(props: ControlPanelProps) {
                       disabled={!onEventArmedChange}
                       size="xs"
                     />
-                  </Box>
+                  </LabeledInput>
                 ))}
             </CommandSection>
           )}
@@ -737,15 +769,19 @@ function ControlPanel(props: ControlPanelProps) {
           {debugVis.length > 0 && onDebugVisChange && (
             <CommandSection label="Debug Viz" expandByDefault={true}>
               {debugVis.map((term) => (
-                <Box key={term.term} px="xs" pb="0.375em">
+                <LabeledInput
+                  key={term.term}
+                  id={`debugvis:${term.term}`}
+                  // The section names what is toggled; the term only tells several apart.
+                  label={debugVis.length > 1 ? `Enable ${formatGroupName(term.term)}` : 'Enable'}
+                >
                   <Checkbox
-                    // The section names what is toggled; the term only tells several apart.
-                    label={debugVis.length > 1 ? `Enable ${formatGroupName(term.term)}` : 'Enable'}
+                    id={`debugvis:${term.term}`}
                     checked={term.enabled}
                     onChange={(event) => onDebugVisChange(term.term, event.currentTarget.checked)}
                     size="xs"
                   />
-                </Box>
+                </LabeledInput>
               ))}
             </CommandSection>
           )}

--- a/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
+++ b/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
@@ -23,7 +23,7 @@ import FloatingPanel from './FloatingPanel';
 import { LabeledInput } from './LabeledInput';
 import { CommandSection } from './CommandSection';
 import { SplatSection } from './SplatSection';
-import type { CommandDescriptor, DebugVisDescriptor } from '../engine';
+import type { CommandDescriptor, DebugVisDescriptor, EventDescriptor } from '../engine';
 
 export interface SelectOption {
   value: string;
@@ -66,6 +66,12 @@ interface ControlPanelProps {
   commandValues: Record<string, number>;
   /** Write a slider/checkbox command value (engine.commands.set). */
   onCommandChange: (id: string, value: number) => void;
+  /** Event terms the operator can drive: manual buttons, interval schedules. */
+  events?: EventDescriptor[];
+  /** Fire a `mode="manual"` event term (engine.events.fire). */
+  onEventFire?: (name: string) => void;
+  /** Start or stop a `mode="interval"` term's schedule (engine.events.setArmed). */
+  onEventArmedChange?: (name: string, armed: boolean) => void;
   /** Command terms with a debug drawing to toggle. */
   debugVis?: DebugVisDescriptor[];
   /** Show or hide one term's debug drawing (engine.debugVis.set). */
@@ -271,6 +277,9 @@ function ControlPanel(props: ControlPanelProps) {
     commands,
     commandValues,
     onCommandChange,
+    events = [],
+    onEventFire,
+    onEventArmedChange,
     debugVis = [],
     onDebugVisChange,
     onReset,
@@ -667,6 +676,46 @@ function ControlPanel(props: ControlPanelProps) {
                 );
               })}
             </>
+          )}
+
+          {/* Events — the scene's disturbances: a button to fire one, a checkbox to
+              let its schedule run. Scene-level, so no policy is needed to drive them. */}
+          {events.length > 0 && (
+            <CommandSection label="Events" expandByDefault={true}>
+              {events.filter((event) => event.kind === 'manual').length > 0 && (
+                <Box px="xs" pb="0.375em" style={{ display: 'flex', flexWrap: 'wrap', gap: '0.375em' }}>
+                  {events
+                    .filter((event) => event.kind === 'manual')
+                    .map((event) => (
+                      <Button
+                        key={event.name}
+                        size="compact-xs"
+                        variant="light"
+                        radius="xs"
+                        onClick={() => onEventFire?.(event.name)}
+                        disabled={!onEventFire}
+                      >
+                        {event.label}
+                      </Button>
+                    ))}
+                </Box>
+              )}
+              {events
+                .filter((event) => event.kind === 'interval')
+                .map((event) => (
+                  <Box key={event.name} px="xs" pb="0.375em">
+                    <Checkbox
+                      label={event.label}
+                      checked={event.armed}
+                      onChange={(changed) =>
+                        onEventArmedChange?.(event.name, changed.currentTarget.checked)
+                      }
+                      disabled={!onEventArmedChange}
+                      size="xs"
+                    />
+                  </Box>
+                ))}
+            </CommandSection>
           )}
 
           {/* Debug Viz — mjlab's own folder, one checkbox per drawing term. */}

--- a/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
+++ b/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
@@ -733,7 +733,7 @@ function ControlPanel(props: ControlPanelProps) {
                       fullWidth
                       style={{ height: '2em' }}
                       onClick={() => onEventFire?.(event.name)}
-                      disabled={!onEventFire}
+                      disabled={!onEventFire || !event.armed}
                     >
                       {event.label}
                     </Button>

--- a/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
+++ b/src/mjswan/template/src/ControlPanel/ControlPanel.tsx
@@ -21,10 +21,8 @@ import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconRefresh, IconSquareX, IconX } from '@tabler/icons-react';
 
 /**
- * Icons an mjlab command GUI can ask for, by the tabler name viser's `Icon` enum spells
- * (`Icon.SQUARE_X` is the string `"square-x"`). Only the ones mjlab actually declares are
- * bundled; anything else renders as a button with no icon rather than pulling the whole
- * icon set into the app.
+ * Icons an mjlab command GUI can ask for, by tabler name (`Icon.SQUARE_X` is
+ * `"square-x"`). Only these are bundled; anything else renders without an icon.
  */
 const COMMAND_BUTTON_ICONS: Record<string, typeof IconSquareX> = {
   'square-x': IconSquareX,
@@ -78,7 +76,7 @@ interface ControlPanelProps {
   commandValues: Record<string, number>;
   /** Write a slider/checkbox command value (engine.commands.set). */
   onCommandChange: (id: string, value: number) => void;
-  /** Press a button command (engine.commands.trigger) — mjlab's `Zero`, and any other. */
+  /** Press a button command (engine.commands.trigger). */
   onCommandTrigger?: (id: string) => void;
   /** Event terms the operator can drive: manual buttons, interval schedules. */
   events?: EventDescriptor[];
@@ -120,15 +118,12 @@ function formatGroupName(groupName: string): string {
     .join(' ');
 }
 
-/** A bound as mjviser prints it under the track end: the number, without float noise. */
+/** The bound as printed under the track end: the number, without float noise. */
 function formatBound(value: number): string {
   return String(Number(value.toFixed(3)));
 }
 
-/**
- * One slider row, in mjviser's layout: the label, the track with its two ends marked,
- * and the value in a box that also takes typing.
- */
+/** One row: the label, the track with both ends marked, and a box that takes typing. */
 function SliderRow({
   id,
   label,
@@ -187,10 +182,7 @@ function SliderRow({
   );
 }
 
-/**
- * SliderControl - one command's slider, preceded by its "Max" companion when the build
- * asked for one, which is the order mjlab's own GUI declares them in.
- */
+/** One command's slider, preceded by its "Max" companion — the order mjlab declares. */
 function SliderControl({
   command,
   value,
@@ -728,8 +720,8 @@ function ControlPanel(props: ControlPanelProps) {
             </CommandSection>
           )}
 
-          {/* Events — the scene's disturbances: a button to fire one, a checkbox to
-              let its schedule run. Scene-level, so no policy is needed to drive them. */}
+          {/* Events: a button fires one, a checkbox lets its schedule run. Scene-level,
+              so no policy is needed to drive them. */}
           {events.length > 0 && (
             <CommandSection label="Events" expandByDefault={true}>
               {events

--- a/src/mjswan/template/src/ControlPanel/LabeledInput.tsx
+++ b/src/mjswan/template/src/ControlPanel/LabeledInput.tsx
@@ -15,7 +15,7 @@ export function LabeledInput({ id, label, children }: LabeledInputProps) {
         <Box
           pr="xs"
           style={{
-            width: "7.25em",
+            width: "5.975em",
             flexShrink: 0,
             position: "relative",
           }}
@@ -29,6 +29,7 @@ export function LabeledInput({ id, label, children }: LabeledInputProps) {
               letterSpacing: "-0.75px",
               width: "100%",
               boxSizing: "content-box",
+              overflowWrap: "anywhere",
             }}
           >
             <label htmlFor={id}>{label}</label>

--- a/src/mjswan/template/src/core/command/CommandManager.ts
+++ b/src/mjswan/template/src/core/command/CommandManager.ts
@@ -299,12 +299,10 @@ export class CommandManager {
 
     const term = this.terms.get(command.groupName);
     const handled = term?.triggerButton?.(command.config.name);
-    // A press can move the term's own inputs — mjlab's Zero sets its sliders — and the
-    // panel reads them from here, so re-read them rather than leave a stale mirror.
+    // mjlab's Zero moves the term's own sliders, and the panel reads them from here.
     this.syncValuesFromTerms();
     if (handled === false && !this.warnedButtons.has(id)) {
-      // The panel draws whatever the build declared, so a name no term answers to
-      // would otherwise be a control that looks live and does nothing.
+      // The panel draws whatever the build declared; an unanswered name looks live.
       this.warnedButtons.add(id);
       console.warn(
         `[CommandManager] "${command.groupName}" has no action for button ` +

--- a/src/mjswan/template/src/core/command/CommandManager.ts
+++ b/src/mjswan/template/src/core/command/CommandManager.ts
@@ -96,6 +96,15 @@ class UiCommand implements CommandTerm {
     this.values.set(input.name, clamped);
     return clamped;
   }
+
+  /** `zero` resets every slider, as mjlab's own Zero button does. */
+  triggerButton(inputName: string): boolean {
+    if (inputName !== 'zero') return false;
+    for (const input of this.inputs) {
+      if (input.type === 'slider') this.values.set(input.name, 0);
+    }
+    return true;
+  }
 }
 
 const BuiltinCommandTerms: Record<string, CommandTermConstructor> = {
@@ -110,6 +119,8 @@ export class CommandManager {
   private values: Map<string, number> = new Map();
   private listeners: Set<CommandEventListener> = new Set();
   private context: CommandTermContext | null = null;
+  /** Buttons already reported as unhandled, so a repeated press is not a repeated log. */
+  private warnedButtons: Set<string> = new Set();
 
   initialize(
     commandsConfig: CommandsConfig,
@@ -287,7 +298,19 @@ export class CommandManager {
     }
 
     const term = this.terms.get(command.groupName);
-    term?.triggerButton?.(command.config.name);
+    const handled = term?.triggerButton?.(command.config.name);
+    // A press can move the term's own inputs — mjlab's Zero sets its sliders — and the
+    // panel reads them from here, so re-read them rather than leave a stale mirror.
+    this.syncValuesFromTerms();
+    if (handled === false && !this.warnedButtons.has(id)) {
+      // The panel draws whatever the build declared, so a name no term answers to
+      // would otherwise be a control that looks live and does nothing.
+      this.warnedButtons.add(id);
+      console.warn(
+        `[CommandManager] "${command.groupName}" has no action for button ` +
+          `"${command.config.name}".`,
+      );
+    }
 
     this.emit({
       type: 'button',
@@ -316,6 +339,7 @@ export class CommandManager {
     this.commands.clear();
     this.commandGroups.clear();
     this.values.clear();
+    this.warnedButtons.clear();
     this.context = null;
     this.emit({ type: 'clear', commandId: '' });
   }

--- a/src/mjswan/template/src/core/command/CommandManager.ts
+++ b/src/mjswan/template/src/core/command/CommandManager.ts
@@ -302,7 +302,6 @@ export class CommandManager {
     // mjlab's Zero moves the term's own sliders, and the panel reads them from here.
     this.syncValuesFromTerms();
     if (handled === false && !this.warnedButtons.has(id)) {
-      // The panel draws whatever the build declared; an unanswered name looks live.
       this.warnedButtons.add(id);
       console.warn(
         `[CommandManager] "${command.groupName}" has no action for button ` +

--- a/src/mjswan/template/src/core/command/OnnxCommand.ts
+++ b/src/mjswan/template/src/core/command/OnnxCommand.ts
@@ -212,12 +212,13 @@ export class OnnxCommand implements CommandTerm {
     return value;
   }
 
-  triggerButton(inputName: string): void {
-    // mjlab's Zero button.
-    if (inputName !== 'zero') return;
+  triggerButton(inputName: string): boolean {
+    // mjlab's Zero button, the one its command GUIs declare.
+    if (inputName !== 'zero') return false;
     for (const input of this.cfg.ui?.inputs ?? []) {
       if (input.type === 'slider') this.uiValues.set(input.name, 0);
     }
+    return true;
   }
 
   /** Run one graph evaluation. Exposed for tests//deterministic stepping. */

--- a/src/mjswan/template/src/core/command/OnnxCommand.ts
+++ b/src/mjswan/template/src/core/command/OnnxCommand.ts
@@ -213,7 +213,7 @@ export class OnnxCommand implements CommandTerm {
   }
 
   triggerButton(inputName: string): boolean {
-    // mjlab's Zero button, the one its command GUIs declare.
+    // mjlab's Zero button.
     if (inputName !== 'zero') return false;
     for (const input of this.cfg.ui?.inputs ?? []) {
       if (input.type === 'slider') this.uiValues.set(input.name, 0);

--- a/src/mjswan/template/src/core/command/__tests__/CommandManager.test.ts
+++ b/src/mjswan/template/src/core/command/__tests__/CommandManager.test.ts
@@ -221,6 +221,89 @@ describe('CommandManager: UiCommand state field', () => {
 });
 
 /**
+ * Button commands. The panel draws these now, so a press has to reach the term and the
+ * values it moved have to reach back: mjlab's `Zero` sets its own sliders, and the
+ * panel reads slider values off the manager's mirror of them.
+ */
+describe('CommandManager: button commands', () => {
+  const context = {
+    mujoco: {} as unknown as CommandTermContext['mujoco'],
+    mjModel: null,
+    mjData: null,
+    scene: {} as unknown as CommandTermContext['scene'],
+  };
+  const withButton = (buttonName: string): CommandsConfig =>
+    ({
+      twist: {
+        name: 'UiCommand',
+        ui: {
+          inputs: [
+            { type: 'slider', name: 'lin_vel_x', label: 'Forward', min: -1, max: 1, default: 0.5, step: 0.05 },
+            { type: 'slider', name: 'ang_vel_z', label: 'Yaw', min: -1, max: 1, default: -0.4, step: 0.05 },
+            { type: 'button', name: buttonName, label: 'Zero' },
+          ],
+        },
+      },
+    }) as unknown as CommandsConfig;
+
+  it('registers a button as a command of its own, with no value', () => {
+    const mgr = new CommandManager();
+    mgr.initialize(withButton('zero'), context as CommandTermContext);
+    const button = mgr.getCommands().find(cmd => cmd.config.type === 'button');
+    expect(button?.id).toBe('twist:zero');
+    // Only value inputs are mirrored; a button has nothing to mirror.
+    expect(mgr.getValues()['twist:zero']).toBeUndefined();
+  });
+
+  it('zeroes the sliders it belongs to, and the panel sees it', () => {
+    const mgr = new CommandManager();
+    mgr.initialize(withButton('zero'), context as CommandTermContext);
+    expect(mgr.getValues()['twist:lin_vel_x']).toBe(0.5);
+    mgr.triggerButton('twist:zero');
+    // The term moved its own sliders; the mirror the panel reads must follow.
+    expect(mgr.getValues()['twist:lin_vel_x']).toBe(0);
+    expect(mgr.getValues()['twist:ang_vel_z']).toBe(0);
+    const term = mgr.getTerm('twist') as unknown as {
+      getStateField(field: string): Float32Array | null;
+    };
+    expect(Array.from(term.getStateField('command')!)).toEqual([0, 0]);
+  });
+
+  it('emits a button event so a host app can hear the press', () => {
+    const mgr = new CommandManager();
+    mgr.initialize(withButton('zero'), context as CommandTermContext);
+    const seen: string[] = [];
+    mgr.addEventListener(event => {
+      if (event.type === 'button') seen.push(event.commandId);
+    });
+    mgr.triggerButton('twist:zero');
+    expect(seen).toEqual(['twist:zero']);
+  });
+
+  it('warns once for a name no term answers to, rather than looking live', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mgr = new CommandManager();
+    mgr.initialize(withButton('launch'), context as CommandTermContext);
+    mgr.triggerButton('twist:launch');
+    mgr.triggerButton('twist:launch');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('launch');
+    warn.mockRestore();
+  });
+
+  it('ignores an id that is not a button', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mgr = new CommandManager();
+    mgr.initialize(withButton('zero'), context as CommandTermContext);
+    mgr.triggerButton('twist:lin_vel_x');
+    mgr.triggerButton('nope');
+    expect(mgr.getValues()['twist:lin_vel_x']).toBe(0.5);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+/**
  * What the Debug Viz panel section lists, mirroring mjlab's `create_debug_vis_gui`:
  * only terms that draw, toggled through the term itself rather than a UI-side copy.
  */

--- a/src/mjswan/template/src/core/command/__tests__/CommandManager.test.ts
+++ b/src/mjswan/template/src/core/command/__tests__/CommandManager.test.ts
@@ -221,9 +221,8 @@ describe('CommandManager: UiCommand state field', () => {
 });
 
 /**
- * Button commands. The panel draws these now, so a press has to reach the term and the
- * values it moved have to reach back: mjlab's `Zero` sets its own sliders, and the
- * panel reads slider values off the manager's mirror of them.
+ * Button commands: a press has to reach the term, and the values it moved have to reach
+ * back — mjlab's `Zero` sets its own sliders and the panel reads them off the mirror.
  */
 describe('CommandManager: button commands', () => {
   const context = {

--- a/src/mjswan/template/src/core/command/__tests__/OnnxCommand.test.ts
+++ b/src/mjswan/template/src/core/command/__tests__/OnnxCommand.test.ts
@@ -378,8 +378,16 @@ describe('OnnxCommand: UI override (mjlab play parity, §3a)', () => {
     await cmd.step(true);
     cmd.setValue('enabled', 1);
     cmd.setValue('lin_vel_x', 0.9);
-    cmd.triggerButton('zero');
+    expect(cmd.triggerButton('zero')).toBe(true);
     expect(Array.from(cmd.getCommand())).toEqual([0, 0, 0]);
+  });
+
+  it('says so for a button it has no action for', () => {
+    // The panel draws every button the build declared, and mjlab's command GUIs are
+    // free to declare one this class knows nothing about.
+    const session = new FakeSession(() => velocityOutputs(0.4, 0.1, -0.2));
+    const cmd = new OnnxCommand('twist', UI_CFG, null, { session, rng: new SeededRng(1) });
+    expect(cmd.triggerButton('start_here')).toBe(false);
   });
 });
 

--- a/src/mjswan/template/src/core/command/__tests__/OnnxCommand.test.ts
+++ b/src/mjswan/template/src/core/command/__tests__/OnnxCommand.test.ts
@@ -383,8 +383,7 @@ describe('OnnxCommand: UI override (mjlab play parity, §3a)', () => {
   });
 
   it('says so for a button it has no action for', () => {
-    // The panel draws every button the build declared, and mjlab's command GUIs are
-    // free to declare one this class knows nothing about.
+    // mjlab's command GUIs are free to declare a button this class has no action for.
     const session = new FakeSession(() => velocityOutputs(0.4, 0.1, -0.2));
     const cmd = new OnnxCommand('twist', UI_CFG, null, { session, rng: new SeededRng(1) });
     expect(cmd.triggerButton('start_here')).toBe(false);

--- a/src/mjswan/template/src/core/command/types.ts
+++ b/src/mjswan/template/src/core/command/types.ts
@@ -117,10 +117,7 @@ export interface CommandTerm {
   setValue?(inputName: string, value: number): number | void;
   /** Current value of one UI input, for the panel's mirror of it. */
   getUiValue?(inputName: string): number | undefined;
-  /**
-   * A button press. Return false for a name the term does nothing with, so the panel can
-   * say so; a term returning nothing is taken at its word.
-   */
+  /** A press. Return false for a name the term does nothing with; nothing means handled. */
   triggerButton?(inputName: string): boolean | void;
   dispose?(): void;
 }

--- a/src/mjswan/template/src/core/command/types.ts
+++ b/src/mjswan/template/src/core/command/types.ts
@@ -35,7 +35,7 @@ export interface ButtonCommandConfig {
   type: 'button';
   name: string;
   label: string;
-  /** Tabler icon name, as viser's `Icon` enum spells it; unknown ones simply go undrawn. */
+  /** Tabler icon name, as viser's `Icon` spells it; an unknown one goes undrawn. */
   icon?: string;
 }
 
@@ -118,8 +118,8 @@ export interface CommandTerm {
   /** Current value of one UI input, for the panel's mirror of it. */
   getUiValue?(inputName: string): number | undefined;
   /**
-   * A button press. Return false for a name the term does nothing with, so the panel's
-   * button is not silently dead; a term returning nothing is taken at its word.
+   * A button press. Return false for a name the term does nothing with, so the panel can
+   * say so; a term returning nothing is taken at its word.
    */
   triggerButton?(inputName: string): boolean | void;
   dispose?(): void;

--- a/src/mjswan/template/src/core/command/types.ts
+++ b/src/mjswan/template/src/core/command/types.ts
@@ -115,7 +115,11 @@ export interface CommandTerm {
   setValue?(inputName: string, value: number): number | void;
   /** Current value of one UI input, for the panel's mirror of it. */
   getUiValue?(inputName: string): number | undefined;
-  triggerButton?(inputName: string): void;
+  /**
+   * A button press. Return false for a name the term does nothing with, so the panel's
+   * button is not silently dead; a term returning nothing is taken at its word.
+   */
+  triggerButton?(inputName: string): boolean | void;
   dispose?(): void;
 }
 

--- a/src/mjswan/template/src/core/command/types.ts
+++ b/src/mjswan/template/src/core/command/types.ts
@@ -35,6 +35,8 @@ export interface ButtonCommandConfig {
   type: 'button';
   name: string;
   label: string;
+  /** Tabler icon name, as viser's `Icon` enum spells it; unknown ones simply go undrawn. */
+  icon?: string;
 }
 
 export interface CheckboxCommandConfig {

--- a/src/mjswan/template/src/core/engine/runtime.ts
+++ b/src/mjswan/template/src/core/engine/runtime.ts
@@ -43,7 +43,7 @@ import type { PolicyConfig } from '../policy/types';
 import { TrackingPolicy } from '../policy/modules/TrackingPolicy';
 import { LocomotionPolicy } from '../policy/modules/LocomotionPolicy';
 import { CommandManager, type CommandTermContext, type CommandsConfig } from '../command';
-import { EventManager } from '../event/EventManager';
+import { EventManager, type EventControl } from '../event/EventManager';
 import { Events } from '../event/events';
 import type { EventConfig, EventContext, TerrainData } from '../event/EventBase';
 import { OnnxSessionCache, type SlotReader } from '../onnx/session';
@@ -631,6 +631,32 @@ export class mjswanRuntime {
   /** The seed this instance's traced terms draw from, so an app can persist it. */
   get seed(): number {
     return this.termSeed;
+  }
+
+  /** The event controls this scene offers: a button per manual term, a checkbox per interval. */
+  eventControls(): EventControl[] {
+    return this.eventManager?.controls() ?? [];
+  }
+
+  /** Fire one `mode="manual"` event term — the operator pressed its button. */
+  async fireEvent(name: string): Promise<void> {
+    if (!this.eventManager || !this.mjModel || !this.mjData) return;
+    try {
+      await this.eventManager.fire(name, this.eventContext());
+    } catch (error) {
+      console.warn(`[mjswanRuntime] manual event "${name}" failed:`, error);
+      return;
+    }
+    // Publish the write even while paused, so the operator sees what they asked for.
+    if (!this.running && this.mjModel && this.mjData) {
+      this.mujoco.mj_forward(this.mjModel, this.mjData);
+      this.updateCachedState();
+    }
+  }
+
+  /** Start or stop one `mode="interval"` term's schedule. */
+  setEventArmed(name: string, armed: boolean): void {
+    this.eventManager?.setArmed(name, armed);
   }
 
   /** Resume the physics loop (rendering runs continuously regardless). */

--- a/src/mjswan/template/src/core/engine/runtime.ts
+++ b/src/mjswan/template/src/core/engine/runtime.ts
@@ -638,7 +638,7 @@ export class mjswanRuntime {
     return this.eventManager?.controls() ?? [];
   }
 
-  /** Fire one `mode="manual"` event term — the operator pressed its button. */
+  /** Fire one `mode="manual"` event term. */
   async fireEvent(name: string): Promise<void> {
     if (!this.eventManager || !this.mjModel || !this.mjData) return;
     try {

--- a/src/mjswan/template/src/core/event/EventBase.ts
+++ b/src/mjswan/template/src/core/event/EventBase.ts
@@ -18,6 +18,8 @@ export type EventConfig = {
   min_step_count_between_reset?: number;
   /** Control-panel text: a `manual` term's button, an `interval` term's arm checkbox. */
   label?: string;
+  /** `mode="manual"` only: the `mode="interval"` term whose armed schedule greys it out. */
+  disabled_when?: string;
 };
 
 export type EventContext = {

--- a/src/mjswan/template/src/core/event/EventBase.ts
+++ b/src/mjswan/template/src/core/event/EventBase.ts
@@ -4,7 +4,7 @@ export type EventConfig = {
   name: string;
   params?: Record<string, unknown>;
   /** Set for an ONNX-backed event; without `mode`/`onnx` it is a reset-only plugin term. */
-  mode?: 'startup' | 'reset' | 'interval';
+  mode?: 'startup' | 'reset' | 'interval' | 'manual';
   /** Set by the build for a term it could not trace; `reason` says why. */
   native?: boolean;
   reason?: string;
@@ -16,6 +16,8 @@ export type EventConfig = {
   interval_range_s?: [number, number];
   is_global_time?: boolean;
   min_step_count_between_reset?: number;
+  /** Control-panel text: a `manual` term's button, an `interval` term's arm checkbox. */
+  label?: string;
 };
 
 export type EventContext = {

--- a/src/mjswan/template/src/core/event/EventManager.ts
+++ b/src/mjswan/template/src/core/event/EventManager.ts
@@ -26,7 +26,8 @@ export interface EventControl {
   label: string;
   /** `manual` renders a button, `interval` an arm checkbox. */
   kind: 'manual' | 'interval';
-  /** `interval` only: whether its schedule is running. Always true for `manual`. */
+  /** `interval`: whether its schedule is running. `manual`: whether its button can
+   * fire — false while the term's `disabled_when` schedule owns the job. */
   armed: boolean;
 }
 
@@ -166,14 +167,28 @@ export class EventManager {
     }
   }
 
+  /** True while a manual term's `disabled_when` interval schedule is armed. */
+  private isGated(manual: OnnxEvent): boolean {
+    const gate = manual.config.disabled_when;
+    if (gate === undefined) return false;
+    return this.intervalTerms.find(({ term }) => term.name === gate)?.trigger.isArmed ?? false;
+  }
+
   /**
-   * Fire one `mode="manual"` term by name, whatever the interval terms are doing.
+   * Fire one `mode="manual"` term by name, unless its `disabled_when` schedule is armed.
    * `OnnxEvent.fire` drops a press that lands while its own graph is still running.
    */
   async fire(name: string, context: EventContext): Promise<void> {
     const term = this.manualTerms.find(entry => entry.name === name);
     if (!term) {
       console.warn(`[EventManager] No mode="manual" event named "${name}".`);
+      return;
+    }
+    if (this.isGated(term)) {
+      // The panel greys the button out, so only an API caller gets here; say why.
+      console.warn(
+        `[EventManager] "${name}" is disabled while "${term.config.disabled_when}" is armed.`,
+      );
       return;
     }
     await term.fire(context);
@@ -194,7 +209,7 @@ export class EventManager {
         name: term.name,
         label: term.config.label ?? term.name,
         kind: 'manual' as const,
-        armed: true,
+        armed: !this.isGated(term),
       })),
       ...this.intervalTerms.map(({ term, trigger }) => ({
         name: term.name,

--- a/src/mjswan/template/src/core/event/EventManager.ts
+++ b/src/mjswan/template/src/core/event/EventManager.ts
@@ -26,8 +26,8 @@ export interface EventControl {
   label: string;
   /** `manual` renders a button, `interval` an arm checkbox. */
   kind: 'manual' | 'interval';
-  /** `interval`: whether its schedule is running. `manual`: whether its button can
-   * fire — false while the term's `disabled_when` schedule owns the job. */
+  /** `interval`: its schedule is running. `manual`: its button can fire — false while
+   * the term's `disabled_when` schedule owns the job. */
   armed: boolean;
 }
 
@@ -39,8 +39,7 @@ type ResetEntry = PluginTerm | OnnxResetTerm;
 /**
  * Mode-aware event dispatch: `mode="reset"` terms fire on episode reset behind a
  * `ResetTrigger`, `mode="interval"` on the frames their `IntervalTrigger` allows,
- * `mode="startup"` once, and `mode="manual"` only when {@link fire} is called, which is
- * the whole schedule such a term has.
+ * `mode="startup"` once, and `mode="manual"` only when {@link fire} is called.
  *
  * One graph per term, unfused — the reference tasks have at most two reset terms and
  * none of the other modes, and fusing would have to reproduce the config-order write
@@ -202,7 +201,6 @@ export class EventManager {
     return true;
   }
 
-  /** A button per manual term, a checkbox per interval one. */
   controls(): EventControl[] {
     return [
       ...this.manualTerms.map(term => ({

--- a/src/mjswan/template/src/core/event/EventManager.ts
+++ b/src/mjswan/template/src/core/event/EventManager.ts
@@ -19,6 +19,17 @@ export interface EventManagerDeps {
   readSlot?: SlotReader;
 }
 
+/** One control the panel offers for an event term. */
+export interface EventControl {
+  name: string;
+  /** The term's own `label`, or its name when it declared none. */
+  label: string;
+  /** `manual` renders a button, `interval` an arm checkbox. */
+  kind: 'manual' | 'interval';
+  /** `interval` only: whether its schedule is running. Always true for `manual`. */
+  armed: boolean;
+}
+
 /** A plugin-supplied event class — reset-only, no traced graph. */
 type PluginTerm = { kind: 'plugin'; term: EventBase; trigger: ResetTrigger };
 type OnnxResetTerm = { kind: 'onnx'; term: OnnxEvent; trigger: ResetTrigger };
@@ -27,7 +38,8 @@ type ResetEntry = PluginTerm | OnnxResetTerm;
 /**
  * Mode-aware event dispatch: `mode="reset"` terms fire on episode reset behind a
  * `ResetTrigger`, `mode="interval"` on the frames their `IntervalTrigger` allows,
- * `mode="startup"` once.
+ * `mode="startup"` once, and `mode="manual"` only when {@link fire} is called — the
+ * control panel's button, which is the whole schedule such a term has.
  *
  * One graph per term, unfused — the reference tasks have at most two reset terms and
  * none of the other modes, and fusing would have to reproduce the config-order write
@@ -36,6 +48,7 @@ type ResetEntry = PluginTerm | OnnxResetTerm;
 export class EventManager {
   private resetTerms: ResetEntry[] = [];
   private intervalTerms: Array<{ term: OnnxEvent; trigger: IntervalTrigger }> = [];
+  private manualTerms: OnnxEvent[] = [];
   private startupTerms: Array<{ term: OnnxEvent; trigger: StartupTrigger }> = [];
   /** Model-field randomizations, applied once by `startup()` (see `modelFieldDr`). */
   private modelFieldTerms: Array<{ config: ModelFieldDrConfig; trigger: StartupTrigger }> = [];
@@ -65,6 +78,9 @@ export class EventManager {
         }
         const term = new OnnxEvent(config, { session, rng: deps.rng, readSlot: deps.readSlot });
         switch (config.mode) {
+          case 'manual':
+            this.manualTerms.push(term);
+            break;
           case 'startup':
             this.startupTerms.push({ term, trigger: new StartupTrigger() });
             break;
@@ -151,6 +167,46 @@ export class EventManager {
   }
 
   /**
+   * Fire one `mode="manual"` term by name — the operator asked for it, so it fires
+   * whatever the interval terms are doing. `OnnxEvent.fire` drops a call that arrives
+   * while its own graph is still running, so a held-down button cannot queue a backlog.
+   */
+  async fire(name: string, context: EventContext): Promise<void> {
+    const term = this.manualTerms.find(entry => entry.name === name);
+    if (!term) {
+      console.warn(`[EventManager] No mode="manual" event named "${name}".`);
+      return;
+    }
+    await term.fire(context);
+  }
+
+  /** Start or stop one `mode="interval"` term's schedule. False if there is no such term. */
+  setArmed(name: string, armed: boolean): boolean {
+    const entry = this.intervalTerms.find(({ term }) => term.name === name);
+    if (!entry) return false;
+    entry.trigger.setArmed(armed);
+    return true;
+  }
+
+  /** What the control panel can offer: a button per manual term, a checkbox per interval one. */
+  controls(): EventControl[] {
+    return [
+      ...this.manualTerms.map(term => ({
+        name: term.name,
+        label: term.config.label ?? term.name,
+        kind: 'manual' as const,
+        armed: true,
+      })),
+      ...this.intervalTerms.map(({ term, trigger }) => ({
+        name: term.name,
+        label: term.config.label ?? term.name,
+        kind: 'interval' as const,
+        armed: trigger.isArmed,
+      })),
+    ];
+  }
+
+  /**
    * Fire every `mode="reset"` term whose gate allows it, **in config order**. Sequential
    * rather than `Promise.all`: every write is an assignment over `default_*`, so the
    * order decides which value survives an overlap.
@@ -168,6 +224,7 @@ export class EventManager {
     return (
       this.resetTerms.length +
       this.intervalTerms.length +
+      this.manualTerms.length +
       this.startupTerms.length +
       // Counted: a task whose only events are DR would otherwise report "0 loaded".
       this.modelFieldTerms.length

--- a/src/mjswan/template/src/core/event/EventManager.ts
+++ b/src/mjswan/template/src/core/event/EventManager.ts
@@ -38,8 +38,8 @@ type ResetEntry = PluginTerm | OnnxResetTerm;
 /**
  * Mode-aware event dispatch: `mode="reset"` terms fire on episode reset behind a
  * `ResetTrigger`, `mode="interval"` on the frames their `IntervalTrigger` allows,
- * `mode="startup"` once, and `mode="manual"` only when {@link fire} is called — the
- * control panel's button, which is the whole schedule such a term has.
+ * `mode="startup"` once, and `mode="manual"` only when {@link fire} is called, which is
+ * the whole schedule such a term has.
  *
  * One graph per term, unfused — the reference tasks have at most two reset terms and
  * none of the other modes, and fusing would have to reproduce the config-order write
@@ -167,9 +167,8 @@ export class EventManager {
   }
 
   /**
-   * Fire one `mode="manual"` term by name — the operator asked for it, so it fires
-   * whatever the interval terms are doing. `OnnxEvent.fire` drops a call that arrives
-   * while its own graph is still running, so a held-down button cannot queue a backlog.
+   * Fire one `mode="manual"` term by name, whatever the interval terms are doing.
+   * `OnnxEvent.fire` drops a press that lands while its own graph is still running.
    */
   async fire(name: string, context: EventContext): Promise<void> {
     const term = this.manualTerms.find(entry => entry.name === name);
@@ -188,7 +187,7 @@ export class EventManager {
     return true;
   }
 
-  /** What the control panel can offer: a button per manual term, a checkbox per interval one. */
+  /** A button per manual term, a checkbox per interval one. */
   controls(): EventControl[] {
     return [
       ...this.manualTerms.map(term => ({

--- a/src/mjswan/template/src/core/event/OnnxEvent.ts
+++ b/src/mjswan/template/src/core/event/OnnxEvent.ts
@@ -17,7 +17,7 @@ import type { OnnxInputSlot, OnnxSession, OnnxTensorLike, SlotReader } from '../
 import { applyEntityWrites, type WriteTarget, type WriteValues } from './entityWrite';
 import type { EventContext } from './EventBase';
 
-export type EventMode = 'startup' | 'reset' | 'interval';
+export type EventMode = 'startup' | 'reset' | 'interval' | 'manual';
 
 export interface OnnxEventConfig {
   name: string;
@@ -33,6 +33,8 @@ export interface OnnxEventConfig {
   is_global_time?: boolean;
   /** `mode="reset"` only: suppress firing on resets that arrive too soon. */
   min_step_count_between_reset?: number;
+  /** Control-panel text: a `manual` term's button, an `interval` term's arm checkbox. */
+  label?: string;
 }
 
 export function isOnnxEventConfig(config: unknown): config is OnnxEventConfig {

--- a/src/mjswan/template/src/core/event/OnnxEvent.ts
+++ b/src/mjswan/template/src/core/event/OnnxEvent.ts
@@ -35,6 +35,8 @@ export interface OnnxEventConfig {
   min_step_count_between_reset?: number;
   /** Control-panel text: a `manual` term's button, an `interval` term's arm checkbox. */
   label?: string;
+  /** `mode="manual"` only: the `mode="interval"` term whose armed schedule greys it out. */
+  disabled_when?: string;
 }
 
 export function isOnnxEventConfig(config: unknown): config is OnnxEventConfig {

--- a/src/mjswan/template/src/core/event/__tests__/EventManager.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/EventManager.test.ts
@@ -292,6 +292,44 @@ describe('EventManager: mode="manual" — the operator is the schedule', () => {
     expect(runFn).toHaveBeenCalledTimes(2);
   });
 
+  it('disarms the button while its `disabled_when` schedule is armed', async () => {
+    const runFn = vi.fn(() => ({}));
+    const deps = await depsWithSession('event/throw.onnx', fakeSession(runFn));
+    const mgr = new EventManager(
+      [
+        {
+          name: 'throw_overhead',
+          mode: 'manual',
+          onnx: 'event/throw.onnx',
+          rand_dim: 0,
+          disabled_when: 'throw_ball',
+        },
+        {
+          name: 'throw_ball',
+          mode: 'interval',
+          onnx: 'event/throw.onnx',
+          rand_dim: 0,
+          interval_range_s: [1.0, 1.0],
+        },
+      ],
+      {},
+      deps,
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Interval terms load armed, so the panel greys the button out from the start.
+    expect(mgr.controls()[0].armed).toBe(false);
+    await mgr.fire('throw_overhead', NO_MODEL);
+    expect(runFn).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+
+    // Auto throw off: the button is the only thrower again.
+    expect(mgr.setArmed('throw_ball', false)).toBe(true);
+    expect(mgr.controls()[0].armed).toBe(true);
+    await mgr.fire('throw_overhead', NO_MODEL);
+    expect(runFn).toHaveBeenCalledTimes(1);
+  });
+
   it('reports a name it cannot arm rather than pretending', async () => {
     const mgr = await bothKinds(vi.fn(() => ({})));
     expect(mgr.setArmed('throw_overhead', false)).toBe(false);

--- a/src/mjswan/template/src/core/event/__tests__/EventManager.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/EventManager.test.ts
@@ -185,6 +185,120 @@ describe('EventManager: mode="interval" — genuinely new dispatch', () => {
   });
 });
 
+describe('EventManager: mode="manual" — the operator is the schedule', () => {
+  /** One manual term and one interval term over the same graph path. */
+  async function bothKinds(runFn: () => Record<string, never>) {
+    const deps = await depsWithSession('event/throw.onnx', fakeSession(runFn));
+    return new EventManager(
+      [
+        {
+          name: 'throw_overhead',
+          mode: 'manual',
+          onnx: 'event/throw.onnx',
+          rand_dim: 0,
+          label: 'Throw overhead',
+        },
+        {
+          name: 'throw_ball',
+          mode: 'interval',
+          onnx: 'event/throw.onnx',
+          rand_dim: 0,
+          interval_range_s: [1.0, 1.0],
+          label: 'Auto throw',
+        },
+      ],
+      {},
+      deps,
+    );
+  }
+
+  it('never fires on its own — not on startup, reset or a tick', async () => {
+    const runFn = vi.fn(() => ({}));
+    const deps = await depsWithSession('event/throw.onnx', fakeSession(runFn));
+    const mgr = new EventManager(
+      [{ name: 'throw_overhead', mode: 'manual', onnx: 'event/throw.onnx', rand_dim: 0 }],
+      {},
+      deps,
+    );
+    await mgr.startup(NO_MODEL);
+    await mgr.onReset(NO_MODEL);
+    await mgr.tick(10, NO_MODEL);
+    expect(runFn).not.toHaveBeenCalled();
+    // Counted all the same: a scene whose only event is manual is not "0 loaded".
+    expect(mgr.size).toBe(1);
+  });
+
+  it('fires when asked, by name, as often as asked', async () => {
+    const runFn = vi.fn(() => ({}));
+    const mgr = await bothKinds(runFn);
+    await mgr.fire('throw_overhead', NO_MODEL);
+    await mgr.fire('throw_overhead', NO_MODEL);
+    expect(runFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns rather than throwing for a name that is not a manual term', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const runFn = vi.fn(() => ({}));
+    const mgr = await bothKinds(runFn);
+    // An interval term is not the operator's to fire directly.
+    await mgr.fire('throw_ball', NO_MODEL);
+    expect(runFn).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('offers one control per term, labelled as the build declared', async () => {
+    const mgr = await bothKinds(vi.fn(() => ({})));
+    expect(mgr.controls()).toEqual([
+      { name: 'throw_overhead', label: 'Throw overhead', kind: 'manual', armed: true },
+      { name: 'throw_ball', label: 'Auto throw', kind: 'interval', armed: true },
+    ]);
+  });
+
+  it('falls back to the term name when the build declared no label', async () => {
+    const deps = await depsWithSession('event/throw.onnx', fakeSession(vi.fn(() => ({}))));
+    const mgr = new EventManager(
+      [{ name: 'throw_overhead', mode: 'manual', onnx: 'event/throw.onnx', rand_dim: 0 }],
+      {},
+      deps,
+    );
+    expect(mgr.controls()[0].label).toBe('throw_overhead');
+  });
+
+  it('disarming an interval term stops it while the button keeps working', async () => {
+    const runFn = vi.fn(() => ({}));
+    const mgr = await bothKinds(runFn);
+    expect(mgr.setArmed('throw_ball', false)).toBe(true);
+    for (let i = 0; i < 12; i++) {
+      await mgr.tick(0.25, NO_MODEL);
+      await settle();
+    }
+    expect(runFn).not.toHaveBeenCalled();
+    expect(mgr.controls()[1].armed).toBe(false);
+
+    // The operator's own throw is unaffected by the schedule being off.
+    await mgr.fire('throw_overhead', NO_MODEL);
+    expect(runFn).toHaveBeenCalledTimes(1);
+
+    // Re-armed, it runs again — after a fresh interval, not the moment it comes back.
+    expect(mgr.setArmed('throw_ball', true)).toBe(true);
+    await mgr.tick(0.25, NO_MODEL);
+    await settle();
+    expect(runFn).toHaveBeenCalledTimes(1);
+    for (let i = 0; i < 4; i++) {
+      await mgr.tick(0.25, NO_MODEL);
+      await settle();
+    }
+    expect(runFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a name it cannot arm rather than pretending', async () => {
+    const mgr = await bothKinds(vi.fn(() => ({})));
+    expect(mgr.setArmed('throw_overhead', false)).toBe(false);
+    expect(mgr.setArmed('nope', false)).toBe(false);
+  });
+});
+
 describe('EventManager: mode="startup"', () => {
   it('fires exactly once, on startup(), not on reset or tick', async () => {
     const runFn = vi.fn(() => ({}));

--- a/src/mjswan/template/src/core/event/__tests__/modelFieldDr.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/modelFieldDr.test.ts
@@ -213,6 +213,85 @@ describe('applyModelFieldDr', () => {
   });
 });
 
+describe('geom_size and the bounds that follow it', () => {
+  /** `[size, rbound, aabbHalf]` for one geom, by name. */
+  function bounds(name: string): [number[], number, number[]] {
+    const names = ['floor', 'robot/torso_collision', 'robot/foot_collision'];
+    const i = names.indexOf(name);
+    const size = mjModel.geom_size as ArrayLike<number>;
+    const rbound = mjModel.geom_rbound as ArrayLike<number>;
+    const aabb = mjModel.geom_aabb as ArrayLike<number>;
+    return [
+      [size[i * 3], size[i * 3 + 1], size[i * 3 + 2]],
+      rbound[i],
+      [aabb[i * 6 + 3], aabb[i * 6 + 4], aabb[i * 6 + 5]],
+    ];
+  }
+
+  const sizeConfig = (over: Partial<ModelFieldDrConfig> = {}): ModelFieldDrConfig =>
+    config({
+      name: 'randomize_ball_size',
+      field: 'geom_size',
+      entity_names: ['robot/foot_collision'],
+      axis_ranges: { '0': [0.125, 0.125] },
+      operation: 'abs',
+      uses_defaults: false,
+      recompute_bounds: true,
+      ...over,
+    });
+
+  it("writes a sphere's radius and the broadphase bound with it", () => {
+    // Without the recompute the geom grows while the broadphase keeps 0.05, and the
+    // ball stops colliding at its own surface.
+    expect(apply(sizeConfig(), new SeededRng(1))).toBe(true);
+    const [size, rbound, aabbHalf] = bounds('robot/foot_collision');
+    expect(size[0]).toBeCloseTo(0.125, 6);
+    expect(rbound).toBeCloseTo(0.125, 6);
+    expect(aabbHalf).toEqual([0.125, 0.125, 0.125]);
+  });
+
+  it("leaves an untargeted geom's bounds as compiled", () => {
+    const before = bounds('robot/torso_collision');
+    apply(sizeConfig(), new SeededRng(1));
+    expect(bounds('robot/torso_collision')).toEqual(before);
+  });
+
+  it("uses the box's own bound formula, not the sphere's", () => {
+    apply(
+      sizeConfig({
+        entity_names: ['robot/torso_collision'],
+        axis_ranges: { '0': [2, 2], '1': [2, 2], '2': [2, 2] },
+        operation: 'scale',
+        uses_defaults: true,
+      }),
+      new SeededRng(1),
+    );
+    const [size, rbound, aabbHalf] = bounds('robot/torso_collision');
+    // 0.1 half-extents doubled; a box's bounding sphere is its diagonal.
+    expect(size).toEqual([0.2, 0.2, 0.2]);
+    expect(rbound).toBeCloseTo(Math.sqrt(3) * 0.2, 6);
+    expect(aabbHalf).toEqual([0.2, 0.2, 0.2]);
+  });
+
+  it('leaves the bounds alone for a geom whose size does not define them', () => {
+    // The build refuses a plane, so the runtime only warns rather than inventing one.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const before = bounds('floor');
+    apply(sizeConfig({ entity_names: ['floor'] }), new SeededRng(1));
+    expect(bounds('floor')[1]).toBe(before[1]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does not touch the bounds when the build did not ask', () => {
+    const before = bounds('robot/foot_collision');
+    apply(sizeConfig({ recompute_bounds: false }), new SeededRng(1));
+    expect(bounds('robot/foot_collision')[0][0]).toBeCloseTo(0.125, 6);
+    // Stale on purpose: this is what mjlab's own `geom_friction` path leaves behind.
+    expect(bounds('robot/foot_collision')[1]).toBeCloseTo(before[1], 6);
+  });
+});
+
 describe('isModelFieldDrConfig', () => {
   it('separates it from a traced event', () => {
     expect(isModelFieldDrConfig(config())).toBe(true);

--- a/src/mjswan/template/src/core/event/__tests__/modelFieldDr.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/modelFieldDr.test.ts
@@ -241,8 +241,8 @@ describe('geom_size and the bounds that follow it', () => {
     });
 
   it("writes a sphere's radius and the broadphase bound with it", () => {
-    // Without the recompute the geom grows while the broadphase keeps 0.05, and the
-    // ball stops colliding at its own surface.
+    // Without the recompute the broadphase keeps 0.05 and the ball stops colliding
+    // at its own surface.
     expect(apply(sizeConfig(), new SeededRng(1))).toBe(true);
     const [size, rbound, aabbHalf] = bounds('robot/foot_collision');
     expect(size[0]).toBeCloseTo(0.125, 6);

--- a/src/mjswan/template/src/core/event/__tests__/triggers.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/triggers.test.ts
@@ -51,6 +51,30 @@ describe('IntervalTrigger', () => {
     expect(fired).toBeLessThanOrEqual(30);
   });
 
+  it('does not fire while disarmed, and does not bank the wait', () => {
+    // The operator's "auto off": the countdown stops rather than piling up, so
+    // re-arming cannot fire the disturbance on the very next frame.
+    const t = new IntervalTrigger({ intervalRangeS: [1.0, 1.0] }, new SeededRng(1));
+    t.setArmed(false);
+    let fired = 0;
+    for (let i = 0; i < 40; i++) if (t.tick(0.25)) fired++;
+    expect(fired).toBe(0);
+    expect(t.isArmed).toBe(false);
+
+    t.setArmed(true);
+    expect(t.isArmed).toBe(true);
+    expect(t.secondsUntilNextFiring).toBeCloseTo(1.0, 6);
+    for (let i = 0; i < 3; i++) expect(t.tick(0.25)).toBe(false);
+    expect(t.tick(0.25)).toBe(true);
+  });
+
+  it('arming an already-armed timer leaves its countdown alone', () => {
+    const t = new IntervalTrigger({ intervalRangeS: [1.0, 1.0] }, new SeededRng(1));
+    t.tick(0.75);
+    t.setArmed(true);
+    expect(t.secondsUntilNextFiring).toBeCloseTo(0.25, 6);
+  });
+
   it('per-episode timers restart on reset; global timers keep running', () => {
     const perEpisode = new IntervalTrigger(
       { intervalRangeS: [1.0, 1.0], isGlobalTime: false },

--- a/src/mjswan/template/src/core/event/__tests__/triggers.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/triggers.test.ts
@@ -52,8 +52,7 @@ describe('IntervalTrigger', () => {
   });
 
   it('does not fire while disarmed, and does not bank the wait', () => {
-    // The operator's "auto off": the countdown stops rather than piling up, so
-    // re-arming cannot fire the disturbance on the very next frame.
+    // The countdown stops rather than piling up, so re-arming cannot fire immediately.
     const t = new IntervalTrigger({ intervalRangeS: [1.0, 1.0] }, new SeededRng(1));
     t.setArmed(false);
     let fired = 0;

--- a/src/mjswan/template/src/core/event/__tests__/triggers.test.ts
+++ b/src/mjswan/template/src/core/event/__tests__/triggers.test.ts
@@ -52,7 +52,6 @@ describe('IntervalTrigger', () => {
   });
 
   it('does not fire while disarmed, and does not bank the wait', () => {
-    // The countdown stops rather than piling up, so re-arming cannot fire immediately.
     const t = new IntervalTrigger({ intervalRangeS: [1.0, 1.0] }, new SeededRng(1));
     t.setArmed(false);
     let fired = 0;

--- a/src/mjswan/template/src/core/event/modelFieldDr.ts
+++ b/src/mjswan/template/src/core/event/modelFieldDr.ts
@@ -193,9 +193,9 @@ export function applyModelFieldDr(
 
 /**
  * `geom_rbound` and `geom_aabb` from the sizes just written, as
- * `dr.geom_size._recompute_geom_bounds` computes them: without it a grown geom keeps its
- * compiled bound and stops colliding at its new radius. `geom_aabb` is `(ngeom, 2, 3)` —
- * centre then half-size — and a primitive's centre stays at its origin.
+ * `dr.geom_size._recompute_geom_bounds` computes them — without it a grown geom keeps its
+ * compiled bound and stops colliding at its own surface. `geom_aabb` is `(ngeom, 2, 3)`,
+ * centre then half-size, and a primitive's centre stays at its origin.
  */
 function recomputeGeomBounds(mjModel: MjModel, name: string, indices: number[]): void {
   const size = mjModel.geom_size as ArrayLike<number> | undefined;

--- a/src/mjswan/template/src/core/event/modelFieldDr.ts
+++ b/src/mjswan/template/src/core/event/modelFieldDr.ts
@@ -34,7 +34,16 @@ export interface ModelFieldDrConfig {
   /** Combine against the compiled default rather than the live value. */
   uses_defaults: boolean;
   set_const: boolean;
+  /** `geom_size` only: redo `geom_rbound`/`geom_aabb`, as mjlab does in the same call. */
+  recompute_bounds?: boolean;
 }
+
+/** `mjtGeom` values whose bounds follow from `geom_size` — mjlab's supported set. */
+const GEOM_SPHERE = 2;
+const GEOM_CAPSULE = 3;
+const GEOM_ELLIPSOID = 4;
+const GEOM_CYLINDER = 5;
+const GEOM_BOX = 6;
 
 /**
  * The compiled field values, snapshotted on first touch, so a second `add`/`scale` event
@@ -173,9 +182,70 @@ export function applyModelFieldDr(
     }
   }
 
+  if (config.recompute_bounds) recomputeGeomBounds(mjModel, config.name, indices);
+
   if (config.set_const) {
     // Inertial fields feed precomputed constants, so without this it is half-applied.
     mujoco.mj_setConst(mjModel, mjData);
   }
   return true;
+}
+
+/**
+ * `geom_rbound` and `geom_aabb` from the sizes just written, as mjlab's
+ * `dr.geom_size._recompute_geom_bounds` computes them: without it the broadphase keeps
+ * the compiled bound and a grown geom stops colliding at its new radius.
+ *
+ * `geom_aabb` is `(ngeom, 2, 3)` — centre then half-size — and a primitive's centre
+ * stays at its origin, so only the half-size is written.
+ */
+function recomputeGeomBounds(mjModel: MjModel, name: string, indices: number[]): void {
+  const size = mjModel.geom_size as ArrayLike<number> | undefined;
+  const types = mjModel.geom_type as ArrayLike<number> | undefined;
+  const rbound = mjModel.geom_rbound as unknown as { [index: number]: number } | undefined;
+  const aabb = mjModel.geom_aabb as unknown as { [index: number]: number } | undefined;
+  if (!size || !types || !rbound || !aabb) {
+    console.warn(`[modelFieldDr] "${name}": no geom bounds to recompute in this model.`);
+    return;
+  }
+  for (const index of indices) {
+    const s0 = size[index * 3];
+    const s1 = size[index * 3 + 1];
+    const s2 = size[index * 3 + 2];
+    let bound: number;
+    let half: [number, number, number];
+    switch (types[index]) {
+      case GEOM_SPHERE:
+        bound = s0;
+        half = [s0, s0, s0];
+        break;
+      case GEOM_CAPSULE:
+        bound = s0 + s1;
+        half = [s0, s0, s0 + s1];
+        break;
+      case GEOM_ELLIPSOID:
+        bound = Math.max(s0, s1, s2);
+        half = [s0, s1, s2];
+        break;
+      case GEOM_CYLINDER:
+        bound = Math.sqrt(s0 * s0 + s1 * s1);
+        half = [s0, s0, s1];
+        break;
+      case GEOM_BOX:
+        bound = Math.sqrt(s0 * s0 + s1 * s1 + s2 * s2);
+        half = [s0, s1, s2];
+        break;
+      default:
+        // The build refuses these, so this is the belt to that braces.
+        console.warn(
+          `[modelFieldDr] "${name}": geom ${index} is type ${types[index]}, whose ` +
+            'bounds do not follow from its size; leaving them as compiled.',
+        );
+        continue;
+    }
+    rbound[index] = bound;
+    aabb[index * 6 + 3] = half[0];
+    aabb[index * 6 + 4] = half[1];
+    aabb[index * 6 + 5] = half[2];
+  }
 }

--- a/src/mjswan/template/src/core/event/modelFieldDr.ts
+++ b/src/mjswan/template/src/core/event/modelFieldDr.ts
@@ -192,12 +192,10 @@ export function applyModelFieldDr(
 }
 
 /**
- * `geom_rbound` and `geom_aabb` from the sizes just written, as mjlab's
- * `dr.geom_size._recompute_geom_bounds` computes them: without it the broadphase keeps
- * the compiled bound and a grown geom stops colliding at its new radius.
- *
- * `geom_aabb` is `(ngeom, 2, 3)` — centre then half-size — and a primitive's centre
- * stays at its origin, so only the half-size is written.
+ * `geom_rbound` and `geom_aabb` from the sizes just written, as
+ * `dr.geom_size._recompute_geom_bounds` computes them: without it a grown geom keeps its
+ * compiled bound and stops colliding at its new radius. `geom_aabb` is `(ngeom, 2, 3)` —
+ * centre then half-size — and a primitive's centre stays at its origin.
  */
 function recomputeGeomBounds(mjModel: MjModel, name: string, indices: number[]): void {
   const size = mjModel.geom_size as ArrayLike<number> | undefined;
@@ -236,7 +234,7 @@ function recomputeGeomBounds(mjModel: MjModel, name: string, indices: number[]):
         half = [s0, s1, s2];
         break;
       default:
-        // The build refuses these, so this is the belt to that braces.
+        // The build refuses these; this is the backstop.
         console.warn(
           `[modelFieldDr] "${name}": geom ${index} is type ${types[index]}, whose ` +
             'bounds do not follow from its size; leaving them as compiled.',

--- a/src/mjswan/template/src/core/event/triggers.ts
+++ b/src/mjswan/template/src/core/event/triggers.ts
@@ -49,8 +49,8 @@ export class IntervalTrigger {
   }
 
   /**
-   * A disarmed timer does not count down, and re-arming samples a fresh interval: a
-   * countdown that had run while disarmed would fire the instant it came back.
+   * A disarmed timer stops counting rather than banking the wait, and re-arming samples a
+   * fresh interval — one disarmed near zero would otherwise fire the moment it came back.
    */
   setArmed(armed: boolean): void {
     if (armed === this.armed) return;

--- a/src/mjswan/template/src/core/event/triggers.ts
+++ b/src/mjswan/template/src/core/event/triggers.ts
@@ -9,7 +9,7 @@
 
 import type { SeededRng } from '../rng';
 
-export type EventMode = 'startup' | 'reset' | 'interval';
+export type EventMode = 'startup' | 'reset' | 'interval' | 'manual';
 
 export interface IntervalTriggerConfig {
   /** `[min, max]` seconds between firings, resampled after each firing. */
@@ -21,6 +21,7 @@ export interface IntervalTriggerConfig {
 /** Countdown timer for one `mode="interval"` event term. */
 export class IntervalTrigger {
   private timeLeft: number;
+  private armed = true;
 
   constructor(
     private readonly config: IntervalTriggerConfig,
@@ -34,6 +35,7 @@ export class IntervalTrigger {
    * long `dt` cannot drift the average rate, but still fires only once.
    */
   tick(dt: number): boolean {
+    if (!this.armed) return false;
     this.timeLeft -= dt;
     if (this.timeLeft > 0) return false;
     this.timeLeft += this.sampleInterval();
@@ -44,6 +46,21 @@ export class IntervalTrigger {
   /** Episode reset: per-episode timers restart, global timers keep running. */
   onReset(): void {
     if (!this.config.isGlobalTime) this.timeLeft = this.sampleInterval();
+  }
+
+  /**
+   * Arm or disarm the schedule, for an operator who wants the disturbance on demand
+   * only. A disarmed timer does not count down, and re-arming samples a fresh interval:
+   * a countdown that had run while disarmed would fire the instant it came back.
+   */
+  setArmed(armed: boolean): void {
+    if (armed === this.armed) return;
+    this.armed = armed;
+    if (armed) this.timeLeft = this.sampleInterval();
+  }
+
+  get isArmed(): boolean {
+    return this.armed;
   }
 
   get secondsUntilNextFiring(): number {

--- a/src/mjswan/template/src/core/event/triggers.ts
+++ b/src/mjswan/template/src/core/event/triggers.ts
@@ -49,9 +49,8 @@ export class IntervalTrigger {
   }
 
   /**
-   * Arm or disarm the schedule, for an operator who wants the disturbance on demand
-   * only. A disarmed timer does not count down, and re-arming samples a fresh interval:
-   * a countdown that had run while disarmed would fire the instant it came back.
+   * A disarmed timer does not count down, and re-arming samples a fresh interval: a
+   * countdown that had run while disarmed would fire the instant it came back.
    */
   setArmed(armed: boolean): void {
     if (armed === this.armed) return;

--- a/src/mjswan/template/src/engine/createEngine.ts
+++ b/src/mjswan/template/src/engine/createEngine.ts
@@ -106,8 +106,7 @@ class Engine implements MjswanEngine {
       set: (term, enabled) => this.runtime.commands.setDebugVisEnabled(term, enabled),
     };
     this.events = {
-      // Refresh either way: a manual fire changes nothing in the state, but an arm
-      // toggle does, and the panel reads its checkbox from there.
+      // Only the arm toggle changes the snapshot; the panel reads its checkbox from it.
       fire: (name) => {
         void this.runtime.fireEvent(name);
       },

--- a/src/mjswan/template/src/engine/createEngine.ts
+++ b/src/mjswan/template/src/engine/createEngine.ts
@@ -16,6 +16,7 @@ import type {
   CommandDescriptor,
   CreateEngineOptions,
   DebugVisControls,
+  EventControls,
   MjswanEngine,
   MjswanEngineState,
   PolicyInput,
@@ -83,6 +84,7 @@ class Engine implements MjswanEngine {
   readonly camera: CameraControls;
   readonly commands: CommandControls;
   readonly debugVis: DebugVisControls;
+  readonly events: EventControls;
 
   constructor(runtime: mjswanRuntime) {
     this.runtime = runtime;
@@ -102,6 +104,17 @@ class Engine implements MjswanEngine {
     this.debugVis = {
       set: (term, enabled) => this.runtime.commands.setDebugVisEnabled(term, enabled),
     };
+    this.events = {
+      // Refresh either way: a manual fire changes nothing in the state, but an arm
+      // toggle does, and the panel reads its checkbox from there.
+      fire: (name) => {
+        void this.runtime.fireEvent(name);
+      },
+      setArmed: (name, armed) => {
+        this.runtime.setEventArmed(name, armed);
+        this.refresh();
+      },
+    };
   }
 
   private onCommandEvent: CommandEventListener = () => this.refresh();
@@ -116,6 +129,7 @@ class Engine implements MjswanEngine {
       commands: cm.getCommands().map(toDescriptor),
       commandValues: cm.getValues(),
       debugVis: cm.getDebugVisTerms().map(({ name, enabled }) => ({ term: name, enabled })),
+      events: this.runtime.eventControls(),
       termSeed: this.runtime.seed,
     };
   }

--- a/src/mjswan/template/src/engine/createEngine.ts
+++ b/src/mjswan/template/src/engine/createEngine.ts
@@ -28,16 +28,17 @@ import type {
 function toDescriptor(def: CommandDefinition): CommandDescriptor {
   const config = def.config;
   const base = { id: def.id, group: def.groupName, type: config.type, label: config.label };
-  return config.type === 'slider'
-    ? {
-        ...base,
-        min: config.min,
-        max: config.max,
-        step: config.step,
-        enabledWhen: config.enabled_when,
-        adjustableRange: config.adjustable_range,
-      }
-    : base;
+  if (config.type === 'slider') {
+    return {
+      ...base,
+      min: config.min,
+      max: config.max,
+      step: config.step,
+      enabledWhen: config.enabled_when,
+      adjustableRange: config.adjustable_range,
+    };
+  }
+  return config.type === 'button' ? { ...base, icon: config.icon } : base;
 }
 
 /**

--- a/src/mjswan/template/src/engine/types.ts
+++ b/src/mjswan/template/src/engine/types.ts
@@ -115,8 +115,8 @@ export interface EventDescriptor {
   /** The term's own `label`, or its name when it declared none. */
   label: string;
   kind: 'manual' | 'interval';
-  /** `interval`: whether its schedule is running. `manual`: whether its button can
-   * fire — false while the term's `disabled_when` schedule owns the job. */
+  /** `interval`: its schedule is running. `manual`: its button can fire — false while
+   * the term's `disabled_when` schedule owns the job. */
   armed: boolean;
 }
 

--- a/src/mjswan/template/src/engine/types.ts
+++ b/src/mjswan/template/src/engine/types.ts
@@ -106,6 +106,24 @@ export interface DebugVisControls {
   set(term: string, enabled: boolean): void;
 }
 
+/** One event term the operator can drive: a `manual` button or an `interval` schedule. */
+export interface EventDescriptor {
+  /** The term's config name, and the id {@link EventControls} takes. */
+  name: string;
+  /** The term's own `label`, or its name when it declared none. */
+  label: string;
+  kind: 'manual' | 'interval';
+  /** `interval` only: whether its schedule is running. Always true for `manual`. */
+  armed: boolean;
+}
+
+export interface EventControls {
+  /** Fire a `mode="manual"` term now. */
+  fire(name: string): void;
+  /** Start or stop a `mode="interval"` term's schedule. */
+  setArmed(name: string, armed: boolean): void;
+}
+
 /** Immutable snapshot pushed to {@link MjswanEngine.subscribe} listeners. */
 export interface MjswanEngineState {
   phase: 'running' | 'paused';
@@ -116,6 +134,8 @@ export interface MjswanEngineState {
   commandValues: Readonly<Record<string, number>>;
   /** Terms with a debug drawing to toggle; empty when the policy has none. */
   debugVis: ReadonlyArray<DebugVisDescriptor>;
+  /** Event terms the operator can drive; empty when the scene has none. */
+  events: ReadonlyArray<EventDescriptor>;
   /** Reported so an app recording a session can persist it rather than guess. */
   termSeed: number;
 }
@@ -150,6 +170,7 @@ export interface MjswanEngine {
   readonly camera: CameraControls;
   readonly commands: CommandControls;
   readonly debugVis: DebugVisControls;
+  readonly events: EventControls;
 
   // state
   getState(): MjswanEngineState;

--- a/src/mjswan/template/src/engine/types.ts
+++ b/src/mjswan/template/src/engine/types.ts
@@ -79,6 +79,8 @@ export interface CommandDescriptor {
   enabledWhen?: string;
   /** Slider only: a presentational companion that rescales this slider's drag range. */
   adjustableRange?: SliderRangeControl;
+  /** Button only: tabler icon name the build recorded from the term's own GUI. */
+  icon?: string;
 }
 
 /** Bounds of an {@link CommandDescriptor.adjustableRange} companion slider. */

--- a/src/mjswan/template/src/engine/types.ts
+++ b/src/mjswan/template/src/engine/types.ts
@@ -115,7 +115,8 @@ export interface EventDescriptor {
   /** The term's own `label`, or its name when it declared none. */
   label: string;
   kind: 'manual' | 'interval';
-  /** `interval` only: whether its schedule is running. Always true for `manual`. */
+  /** `interval`: whether its schedule is running. `manual`: whether its button can
+   * fire — false while the term's `disabled_when` schedule owns the job. */
   armed: boolean;
 }
 

--- a/src/mjswan/template/src/index.css
+++ b/src/mjswan/template/src/index.css
@@ -78,3 +78,16 @@ body {
   margin: 0;
   opacity: 0.6;
 }
+
+/*
+ * A slider's end labels, tucked inside the track's ends as mjviser tucks them: at
+ * `translate(-50%)` the first would hang off the left edge and the last off the right.
+ * Mantine has no `styles` hook per mark, so the two ends are addressed here.
+ */
+.mantine-Slider-markWrapper:first-of-type .mantine-Slider-markLabel {
+  transform: translate(-0.1rem, 0.03rem) !important;
+}
+
+.mantine-Slider-markWrapper:last-of-type .mantine-Slider-markLabel {
+  transform: translate(-85%, 0.03rem) !important;
+}

--- a/src/mjswan/template/src/index.css
+++ b/src/mjswan/template/src/index.css
@@ -80,8 +80,8 @@ body {
 }
 
 /*
- * A slider's end labels, tucked inside the track as mjviser tucks them — centred, the
- * first hangs off the left edge. Mantine has no `styles` hook for a single mark.
+ * A slider's end labels, tucked inside the track as mjviser tucks them; centred, the
+ * first would hang off the left edge. Mantine has no `styles` hook for a single mark.
  */
 .mantine-Slider-markWrapper:first-of-type .mantine-Slider-markLabel {
   transform: translate(-0.1rem, 0.03rem) !important;

--- a/src/mjswan/template/src/index.css
+++ b/src/mjswan/template/src/index.css
@@ -80,9 +80,8 @@ body {
 }
 
 /*
- * A slider's end labels, tucked inside the track's ends as mjviser tucks them: at
- * `translate(-50%)` the first would hang off the left edge and the last off the right.
- * Mantine has no `styles` hook per mark, so the two ends are addressed here.
+ * A slider's end labels, tucked inside the track as mjviser tucks them — centred, the
+ * first hangs off the left edge. Mantine has no `styles` hook for a single mark.
  */
 .mantine-Slider-markWrapper:first-of-type .mantine-Slider-markLabel {
   transform: translate(-0.1rem, 0.03rem) !important;

--- a/tests/test_gui_spy.py
+++ b/tests/test_gui_spy.py
@@ -109,7 +109,6 @@ def test_an_unknown_viser_control_raises_rather_than_dropping_it():
 
 
 def test_a_buttons_icon_is_recorded_for_the_panel_to_draw():
-    """viser's `Icon` members are plain tabler names, and mjlab's `Zero` carries one."""
     inputs = _inputs(_JoystickTerm())
     assert inputs[-1] == {
         "type": "button",

--- a/tests/test_gui_spy.py
+++ b/tests/test_gui_spy.py
@@ -30,7 +30,7 @@ class _JoystickTerm:
                 server.gui.add_slider(
                     label, min=-limit, max=limit, step=0.05, initial_value=0.0
                 )
-            server.gui.add_button("Zero")
+            server.gui.add_button("Zero", icon="square-x")
 
 
 class _SilentTerm:
@@ -108,6 +108,29 @@ def test_an_unknown_viser_control_raises_rather_than_dropping_it():
         record_gui(_Term(), "twist")
 
 
+def test_a_buttons_icon_is_recorded_for_the_panel_to_draw():
+    """viser's `Icon` members are plain tabler names, and mjlab's `Zero` carries one."""
+    inputs = _inputs(_JoystickTerm())
+    assert inputs[-1] == {
+        "type": "button",
+        "name": "zero",
+        "label": "Zero",
+        "icon": "square-x",
+    }
+
+
+def test_a_button_without_an_icon_says_nothing_about_one():
+    class _Term:
+        def create_gui(
+            self, name, server, get_env_idx, on_change=None, request_action=None
+        ):
+            server.gui.add_button("Start Here")
+
+    assert _inputs(_Term()) == [
+        {"type": "button", "name": "start_here", "label": "Start Here"}
+    ]
+
+
 @pytest.mark.mjlab
 def test_records_mjlabs_real_velocity_joystick():
     """`UniformVelocityCommand.create_gui` reads only `self.cfg.ranges`, so no
@@ -129,6 +152,7 @@ def test_records_mjlabs_real_velocity_joystick():
     inputs = _inputs(term)
 
     # mjlab's viewer labels, verbatim.
+    assert inputs[-1]["icon"] == "square-x"
     assert [(i["type"], i["name"], i["label"]) for i in inputs] == [
         ("checkbox", "enabled", "Enable"),
         ("slider", "lin_vel_x", "lin_vel_x"),

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -37,8 +37,7 @@ GEOM_NAMES = [
     "robot/rf_pad_collision",
 ]
 BODY_NAMES = ["world", "robot/torso", "robot/hand"]
-#: `mjtGeom`: the floor is a plane, the torso a mesh, the tips and pads spheres. Only
-#: `dr.geom_size` reads these — its bounds recompute is defined for primitives alone.
+#: `mjtGeom`: a plane, a mesh, then spheres — `dr.geom_size` refuses non-primitives.
 GEOM_TYPES = [0, 7, 2, 2, 2, 2]
 ROBOT_GEOM_IDS = [1, 2, 3, 4, 5]
 ROBOT_BODY_IDS = [1, 2]
@@ -58,11 +57,7 @@ class _Named:
 
 
 class _MjModel:
-    """Only the accessors the descriptor reaches for: names, and a geom's type.
-
-    Indexed by id or by name, as MuJoCo's own accessor is — `_dr_entity_names` asks by
-    id, `_require_primitive_geoms` by name.
-    """
+    """Names and a geom's type, indexed by id or by name as MuJoCo's accessor is."""
 
     def geom(self, key):
         index = GEOM_NAMES.index(key) if isinstance(key, str) else key
@@ -187,8 +182,7 @@ def body_mass(  # noqa: PLR0917 — mjlab's own arity; the signature is the fixt
 body_com_offset.recompute = 3
 body_mass.recompute = 3
 geom_friction.recompute = 0
-# `requires_model_fields("geom_size", "geom_rbound", "geom_aabb")` — recompute stays none:
-# the bounds are model fields, not the inertial constants `mj_setConst` rebuilds.
+# The bounds are model fields, not the inertial constants `mj_setConst` rebuilds.
 geom_size.recompute = 0
 
 
@@ -517,11 +511,9 @@ def test_serialize_event_emits_the_descriptor_with_its_name_and_mode(tmp_path):
 
 
 class TestGeomSize:
-    """`dr.geom_size`, whose broadphase bounds the browser owes after the write.
+    """`dr.geom_size`: the browser owes the bounds mjlab recomputes in the same call.
 
-    mjlab recomputes `geom_rbound`/`geom_aabb` inside the same call and raises for a geom
-    type whose bounds do not follow from its size; the build knows the types, so it
-    refuses before a bundle exists rather than at the first firing.
+    Geoms whose bounds do not follow from their size are refused at build time.
     """
 
     @staticmethod
@@ -536,7 +528,6 @@ class TestGeomSize:
         assert descriptor["field"] == "geom_size"
         assert descriptor["entity_type"] == "geom"
         assert descriptor["recompute_bounds"] is True
-        # The bounds are model fields, not inertial constants.
         assert descriptor["set_const"] is False
 
     def test_all_three_axes_by_default_as_mjlab_scales_them(self):
@@ -600,7 +591,6 @@ class TestManualEvents:
         )
         assert entry["mode"] == "manual"
         assert entry["label"] == "Throw overhead"
-        # Nothing schedules it, so it carries no schedule.
         assert "interval_range_s" not in entry
         assert "is_global_time" not in entry
         # Still a traced graph writing the entity it was made on.

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -37,6 +37,9 @@ GEOM_NAMES = [
     "robot/rf_pad_collision",
 ]
 BODY_NAMES = ["world", "robot/torso", "robot/hand"]
+#: `mjtGeom`: the floor is a plane, the torso a mesh, the tips and pads spheres. Only
+#: `dr.geom_size` reads these — its bounds recompute is defined for primitives alone.
+GEOM_TYPES = [0, 7, 2, 2, 2, 2]
 ROBOT_GEOM_IDS = [1, 2, 3, 4, 5]
 ROBOT_BODY_IDS = [1, 2]
 
@@ -49,15 +52,21 @@ class _Ids(list):
 
 
 class _Named:
-    def __init__(self, name):
+    def __init__(self, name, type=0):
         self.name = name
+        self.type = type
 
 
 class _MjModel:
-    """Only the name accessors `_dr_entity_names` reaches for."""
+    """Only the accessors the descriptor reaches for: names, and a geom's type.
 
-    def geom(self, i):
-        return _Named(GEOM_NAMES[i])
+    Indexed by id or by name, as MuJoCo's own accessor is — `_dr_entity_names` asks by
+    id, `_require_primitive_geoms` by name.
+    """
+
+    def geom(self, key):
+        index = GEOM_NAMES.index(key) if isinstance(key, str) else key
+        return _Named(GEOM_NAMES[index], GEOM_TYPES[index])
 
     def body(self, i):
         return _Named(BODY_NAMES[i])
@@ -105,7 +114,10 @@ class _Env:
 
 
 class _TermCfg:
-    """Stands in for `EventTermCfg` (only `.func` / `.params` / `.mode` are read)."""
+    """Stands in for `EventTermCfg` (only these fields are read)."""
+
+    interval_range_s = None
+    label = None
 
     def __init__(self, func, params, mode="startup"):
         self.func = func
@@ -145,6 +157,19 @@ def body_com_offset(  # noqa: PLR0917 — mjlab's own arity; the signature is th
     del env, env_ids, ranges, asset_cfg, distribution, operation, axes, shared_random
 
 
+def geom_size(  # noqa: PLR0917 — mjlab's own arity; the signature is the fixture
+    env,
+    env_ids,
+    ranges,
+    asset_cfg=None,
+    distribution="uniform",
+    operation="scale",
+    axes=None,
+    shared_random=False,
+):
+    del env, env_ids, ranges, asset_cfg, distribution, operation, axes, shared_random
+
+
 def body_mass(  # noqa: PLR0917 — mjlab's own arity; the signature is the fixture
     env,
     env_ids,
@@ -162,6 +187,9 @@ def body_mass(  # noqa: PLR0917 — mjlab's own arity; the signature is the fixt
 body_com_offset.recompute = 3
 body_mass.recompute = 3
 geom_friction.recompute = 0
+# `requires_model_fields("geom_size", "geom_rbound", "geom_aabb")` — recompute stays none:
+# the bounds are model fields, not the inertial constants `mj_setConst` rebuilds.
+geom_size.recompute = 0
 
 
 def _fingertips():
@@ -486,6 +514,114 @@ def test_serialize_event_emits_the_descriptor_with_its_name_and_mode(tmp_path):
     # No graph: the browser draws these itself from the seeded stream.
     assert "onnx" not in entry
     assert not list(tmp_path.rglob("*.onnx"))
+
+
+class TestGeomSize:
+    """`dr.geom_size`, whose broadphase bounds the browser owes after the write.
+
+    mjlab recomputes `geom_rbound`/`geom_aabb` inside the same call and raises for a geom
+    type whose bounds do not follow from its size; the build knows the types, so it
+    refuses before a bundle exists rather than at the first firing.
+    """
+
+    @staticmethod
+    def _ball(**params):
+        return _TermCfg(
+            geom_size,
+            {"asset_cfg": _fingertips(), "ranges": (0.075, 0.125), **params},
+        )
+
+    def test_it_describes_the_field_and_asks_for_the_bounds(self):
+        descriptor = model_field_dr_descriptor(self._ball(), _Env())
+        assert descriptor["field"] == "geom_size"
+        assert descriptor["entity_type"] == "geom"
+        assert descriptor["recompute_bounds"] is True
+        # The bounds are model fields, not inertial constants.
+        assert descriptor["set_const"] is False
+
+    def test_all_three_axes_by_default_as_mjlab_scales_them(self):
+        descriptor = model_field_dr_descriptor(self._ball(), _Env())
+        assert descriptor["operation"] == "scale"
+        assert set(descriptor["axis_ranges"]) == {0, 1, 2}
+
+    def test_a_sphere_radius_alone_is_axis_zero(self):
+        """A ball's own randomization: `operation="abs"`, `axes=[0]`."""
+        descriptor = model_field_dr_descriptor(
+            self._ball(operation="abs", axes=[0]), _Env()
+        )
+        assert descriptor["operation"] == "abs"
+        assert descriptor["axis_ranges"] == {0: [0.075, 0.125]}
+
+    def test_a_geom_whose_bounds_do_not_follow_from_its_size_is_refused(self):
+        term = _TermCfg(
+            geom_size,
+            {
+                "asset_cfg": _EntityCfg("robot", geom_names=("robot/torso_collision",)),
+                "ranges": (0.9, 1.1),
+            },
+        )
+        with pytest.raises(ValueError, match="primitive geom types") as excinfo:
+            model_field_dr_descriptor(term, _Env())
+        assert "robot/torso_collision" in str(excinfo.value)
+        assert "MESH" in str(excinfo.value)
+
+    def test_another_field_does_not_ask_for_the_bounds(self):
+        descriptor = model_field_dr_descriptor(
+            _TermCfg(geom_friction, {"asset_cfg": _fingertips(), "ranges": (0.3, 1.5)}),
+            _Env(),
+        )
+        assert descriptor["recompute_bounds"] is False
+
+
+class TestManualEvents:
+    """`mode="manual"`: no schedule at all, fired from the control panel's button."""
+
+    def test_it_serializes_with_its_label_and_no_schedule(self, tmp_path):
+        torch = pytest.importorskip("torch")
+        pytest.importorskip("mjlab")
+        from mjswan._onnx_build import serialize_event
+        from mjswan.managers.event_manager import EventTermCfg
+
+        def throw(env, env_ids, ball_name="ball"):
+            env.scene[ball_name].write_root_link_pose_to_sim(
+                torch.zeros(1, 7), env_ids=env_ids
+            )
+
+        entry = serialize_event(
+            "throw_overhead",
+            EventTermCfg(
+                func=throw,
+                mode="manual",
+                params={"ball_name": "ball"},
+                label="Throw overhead",
+            ),
+            TestWriteTargetEntity._env(),
+            tmp_path,
+        )
+        assert entry["mode"] == "manual"
+        assert entry["label"] == "Throw overhead"
+        # Nothing schedules it, so it carries no schedule.
+        assert "interval_range_s" not in entry
+        assert "is_global_time" not in entry
+        # Still a traced graph writing the entity it was made on.
+        assert entry["write_targets"][0]["entity"] == "ball"
+
+    def test_a_manual_term_carrying_an_interval_is_refused(self, tmp_path):
+        """Two triggers on one term reads as a mistake, and it is a cheap one to catch."""
+        from mjswan._onnx_build import serialize_event
+        from mjswan.managers.event_manager import EventTermCfg
+
+        def throw(env, env_ids):
+            raise AssertionError("never traced")
+
+        with pytest.raises(ValueError, match="manual") as excinfo:
+            serialize_event(
+                "throw",
+                EventTermCfg(func=throw, mode="manual", interval_range_s=(1.0, 4.0)),
+                _Env(),
+                tmp_path,
+            )
+        assert "interval" in str(excinfo.value)
 
 
 class TestAnUntraceableEventFailsTheBuild:

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -596,6 +596,64 @@ class TestManualEvents:
         # Still a traced graph writing the entity it was made on.
         assert entry["write_targets"][0]["entity"] == "ball"
 
+    def test_disabled_when_travels_to_the_browser(self, tmp_path):
+        torch = pytest.importorskip("torch")
+        pytest.importorskip("mjlab")
+        from mjswan._onnx_build import serialize_event
+        from mjswan.managers.event_manager import EventTermCfg
+
+        def throw(env, env_ids, ball_name="ball"):
+            env.scene[ball_name].write_root_link_pose_to_sim(
+                torch.zeros(1, 7), env_ids=env_ids
+            )
+
+        entry = serialize_event(
+            "throw_overhead",
+            EventTermCfg(
+                func=throw,
+                mode="manual",
+                params={"ball_name": "ball"},
+                disabled_when="throw_ball",
+            ),
+            TestWriteTargetEntity._env(),
+            tmp_path,
+        )
+        assert entry["disabled_when"] == "throw_ball"
+
+    def test_a_gate_that_names_no_interval_term_is_refused(self):
+        """A dead gate greys the button out forever, or never — and says nothing."""
+        from mjswan._onnx_build import _check_disabled_when
+        from mjswan.managers.event_manager import EventTermCfg
+
+        def throw(env, env_ids):
+            raise AssertionError("never traced")
+
+        auto = EventTermCfg(func=throw, mode="interval", interval_range_s=(1.0, 4.0))
+        gated = EventTermCfg(func=throw, mode="manual", disabled_when="throw_ball")
+        _check_disabled_when({"throw_overhead": gated, "throw_ball": auto})
+
+        with pytest.raises(ValueError, match="throw_ball"):
+            _check_disabled_when({"throw_overhead": gated})
+        with pytest.raises(ValueError, match="interval"):
+            # The gate must be the schedule, not another button.
+            _check_disabled_when(
+                {
+                    "throw_overhead": gated,
+                    "throw_ball": EventTermCfg(func=throw, mode="manual"),
+                }
+            )
+        with pytest.raises(ValueError, match="manual"):
+            _check_disabled_when(
+                {
+                    "throw_ball": EventTermCfg(
+                        func=throw,
+                        mode="interval",
+                        interval_range_s=(1.0, 4.0),
+                        disabled_when="throw_ball",
+                    )
+                }
+            )
+
     def test_a_manual_term_carrying_an_interval_is_refused(self, tmp_path):
         """Two triggers on one term reads as a mistake, and it is a cheap one to catch."""
         from mjswan._onnx_build import serialize_event

--- a/tests/test_onnx_event_config.py
+++ b/tests/test_onnx_event_config.py
@@ -536,7 +536,6 @@ class TestGeomSize:
         assert set(descriptor["axis_ranges"]) == {0, 1, 2}
 
     def test_a_sphere_radius_alone_is_axis_zero(self):
-        """A ball's own randomization: `operation="abs"`, `axes=[0]`."""
         descriptor = model_field_dr_descriptor(
             self._ball(operation="abs", axes=[0]), _Env()
         )
@@ -655,7 +654,6 @@ class TestManualEvents:
             )
 
     def test_a_manual_term_carrying_an_interval_is_refused(self, tmp_path):
-        """Two triggers on one term reads as a mistake, and it is a cheap one to catch."""
         from mjswan._onnx_build import serialize_event
         from mjswan.managers.event_manager import EventTermCfg
 


### PR DESCRIPTION
Three things the control panel could not offer, the model-field entry one of them wanted, and the shape mjlab's own viewer already has.

## 1. `mode="manual"` event terms

A term with this mode has no schedule at all: it runs when the operator presses its button, which is the whole trigger.

```python
env_cfg.events["throw_overhead"] = EventTermCfg(
    func=terms.throw_ball,
    mode="manual",
    params={**throw_params, "high_fraction": 1.0},
    label="Throw overhead",
)
```

The panel grows an **`Events`** section: one button per manual term, plus one checkbox per `mode="interval"` term that arms or disarms *that* term's schedule — so a scene can offer both the timer the task trains with and the button the viewer actually wants.

- A **disarmed timer stops counting** rather than banking the wait; re-arming samples a fresh interval, because a countdown that had run while disarmed would fire the instant it came back.
- Both are engine verbs too — `engine.events.fire(name)` and `engine.events.setArmed(name, armed)` — with the terms they act on reported as `MjswanEngineState.events`.
- `label` on the term config is the text either control carries, defaulting to the term name.
- A manual term declared with `interval_range_s` is refused: two triggers on one term reads as a mistake, and it is a cheap one to catch (before the tracer is even imported).

**Why a new mode rather than a task-side gate.** mjlab has a viewer to bolt a button onto and plain Python state to gate a term with. PAC-MAN's dodgeball demo does exactly that — a viser folder driving `env._dodge_throw_paused` / `_dodge_throw_once` that its throw event reads back with `getattr` — and none of it survives tracing: an env attribute read in a term body is baked into the graph as a **constant** at build time, so `paused` would be frozen at whatever it was when the bundle was built. The gate has to live in the runtime, which is where this puts it. A manual term left sitting in an mjlab config is inert there, which is what a mode mjlab's `EventManager` never applies should be.

## 2. The panel draws button commands

`button` has been a command input type all along — `CommandManager.triggerButton` routes a press to the term, `engine.commands.trigger` is a verb, and the GUI spy records `add_button` from an mjlab command's own `create_gui`. The panel then filtered its controls down to sliders and checkboxes, so none of it was reachable: **mjlab's `Zero`**, declared by every `UniformVelocityCommand` GUI and sitting in the bundle of every locomotion task, simply did not exist for a viewer.

- Buttons render **in declaration order**, which is where mjlab puts them: `Zero` lands under the sliders it zeroes.
- The values a press moves are re-read from the term afterwards (`syncValuesFromTerms`, the call a reset already uses), because the panel shows the manager's mirror of the term's inputs and `Zero` moves the term's side of it.
- `UiCommand` answers to `zero` too, so a hand-written panel gets the same button without restating what it means.
- A press no term answers to **warns once**, naming the group and the input. The panel draws whatever the build declared, and an mjlab GUI is free to declare a button this runtime knows nothing about (the tracking command's "Start Here" asks its viewer to reset to a scrubbed frame), so a dead-looking control should say why rather than absorb the click. That is what `triggerButton` returning a boolean is for; a term returning nothing is taken at its word.

## 3. An mjlab command renders the way mjlab's own viewer renders it

Two viewers onto the same mjlab task should not look like two products. The reference was **read off a running viser** — `add_folder("Commands") > add_folder("Twist")` with mjlab's own controls, and a running [mjviser](https://github.com/mujocolab/mjviser) for the widget metrics — not from a screenshot.

| | mjlab's viser GUI | mjswan before | mjswan now |
|---|---|---|---|
| groups | nested in a `Commands` folder | one folder per group | nested in `Commands` |
| row | label column `5.975em`, wrapping | 50 % split | `5.975em`, wrapping |
| slider | ends marked + `3rem` number box | bare track | ends marked + number box |
| number box | `1.875em` tall | — | `1.875em` tall |
| slider row | 20.81 px | 27.75 px | 20.81 px |
| checkbox row | 17.81 px | 17.81 px | 17.81 px |
| `Max` companion | above the axis it rescales | below it | above it |
| checkbox | in the control column | captioning itself | in the control column |
| command button | full width, filled, with its icon | tinted `compact-xs` | full width, filled, with its icon |
| slider thumb | `0.5rem × 0.75rem` bar | `12 × 12` dot | `0.5rem × 0.75rem` bar |
| action button | `sm` at `2em` | `xs` at `30px` | `sm` at `2em` |

The number box is not a readout: typing in it moves the command, clamped to the thumb's own range. Its height is the row's — a slider row is as tall as its tallest child, and Mantine's `xs` input stood a third taller than mjviser's box, which is what put the folder out of rhythm. The end marks are labelled with the bounds and tucked inside the track (a `styles` hook cannot address a single mark, so the two ends live in `index.css`, as viser does it). The icon comes from the term: `ButtonConfig` grew an `icon`, the GUI spy records it from `add_button(icon=...)` — viser's `Icon` members are plain tabler names, `Icon.SQUARE_X` is `"square-x"` — and the panel draws the ones it bundles, so an unknown icon renders as a plain button rather than pulling the whole tabler set into the app. Sizes are `em`-relative, so both panels stay identical under their own root font size, and the slider and number-box styling live in the theme, so every one in the app follows.

**One deliberate difference**: mjswan greys a slider whose `enabled_when` checkbox is off, where viser leaves it live. The greying says what is true — those axes do nothing until Enable is ticked — so it stays.

## 4. `dr.geom_size` is described for the browser

It is now in the model-field table, so a task randomizing a geom's size gets it in the browser — and the browser recomputes `geom_rbound` and `geom_aabb` from the size it just wrote, as mjlab does in the same call and by geom type (sphere, capsule, ellipsoid, cylinder, box). Without that, a geom that grows keeps its compiled bound and simply stops colliding at its own surface.

A size randomization on a geom type whose bounds do **not** follow from its size (mesh, plane, hfield, SDF) fails the build, naming the geoms and their types. mjlab raises the same refusal — but only when the event first fires.

## Verification

- `pytest`: **697 passed**. `vitest run`: **391 passed** across 27 suites. `tsc --noEmit`, `eslint src/`, `ruff check`, `ruff format --check` all clean.
- New tests: a manual term never firing on startup / reset / tick; firing by name, as often as asked; an unknown name warning instead of throwing; its label falling back to the term name; a disarmed interval term staying quiet while the button still works, and re-arming on a fresh interval rather than immediately; `setArmed` reporting a name it cannot arm; a button registering as a command with no value of its own; `zero` zeroing a group's sliders through both `UiCommand` and `OnnxCommand`; the panel's mirror following that; the button event still reaching a host listener; one warning per unhandled button name; a non-button id ignored; a button's icon reaching the descriptor and a button without one saying nothing about it; mjlab's real velocity joystick carrying `square-x`; `geom_size` writing a sphere's radius with its bound and a box's with its diagonal; an untargeted geom's bounds left alone; a non-primitive geom refused at build time and left alone at runtime; and a manual term serializing with its label and no schedule.
- End to end in headless Chromium, on `mjswan_playground`'s `pacman`:
  - the walk scene's panel reads **Commands > Twist > Enable / Max lin_vel_x / lin_vel_x / Max lin_vel_y / lin_vel_y / Max ang_vel_z / ang_vel_z / Zero**, in that order, with the end marks and the number boxes; typing `0.75` into a box moves its slider to 0.75; `Zero` takes the three axes to 0 and leaves the `Max` companions alone;
  - every row measured against the reference viser panel: checkbox 17.81 px both, slider rows 20.81 px both, number box 20.81 px both, dropdown rows 24.05 px both;
  - the dodge scene renders `Events` with both throw buttons and the `Auto throw` row; over 40 sampled frames the ball is airborne in **19** with the schedule armed, **0** with it disarmed, and **12** after re-arming; each button launches a ball on its own branch while the schedule is off;
  - no console errors or warnings either way.