### PR TITLE
Raw mjData slots as the slot foundation, with entity fields as a shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ velocity-command shortcuts were removed outright, see Removed.
 
 ### Added
 
+- Raw `mjData` fields as traced-graph slots: a term reading `entity.data.data.<field>`
+  (mjlab's `SimData`, for what `EntityData` does not wrap — a muscle model's `act`, the
+  sim `time`) now traces, with the browser serving the whole field from `mjData`.
+  Replay proxies also forward `physics_dt` / `step_dt` / `cfg` from the real env, and
+  `add_policy` fills `policy_num_actions` from the ONNX output width when a policy has
+  no joint names (muscle policies).
 - **MDP term bodies are traced to ONNX at build time and run by ONNX Runtime Web**
   ([ADR 0005](docs/adr/0005-onnx-traced-terms-superseding-the-declarative-dsl.md)),
   replacing the hand-written TypeScript DSL (see Removed). mjlab's real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ velocity-command shortcuts were removed outright, see Removed.
 
 ### Added
 
+- `MuscleActivationActionCfg.action_mode` (`sigmoid` / `direct` / `excitation`), named
+  as mjlab/myosuite spells it so the adapter copies it across by itself. `direct` writes
+  the raw action clipped to each actuator's own `ctrlrange` — a myosuite muscle model
+  declares `ctrlrange="-1 1"` and a checkpoint trained against the raw control uses the
+  negative half, which `excitation` would clamp to zero. `normalize` stays as the legacy
+  spelling of the other two; the policy JSON now carries `mode` instead of `normalize`,
+  and the engine still reads the old key.
 - Raw `mjData` fields as traced-graph slots: a term reading `entity.data.data.<field>`
   (mjlab's `SimData`, for what `EntityData` does not wrap — a muscle model's `act`, the
   sim `time`) now traces, with the browser serving the whole field from `mjData`.

--- a/docs/docs/guides/how-it-works.md
+++ b/docs/docs/guides/how-it-works.md
@@ -148,9 +148,12 @@ A graph needs the simulation state it reads. The build records that as **slots**
 ]
 ```
 
-Three slot namespaces exist: an entity `data` field (as above), a named MuJoCo sensor's
-`sensordata` window, and a live command's state field. Anything model-derived and
-therefore constant is baked into the graph instead of becoming a slot.
+Four slot namespaces exist: an entity `data` field (as above), a named MuJoCo sensor's
+`sensordata` window, a live command's state field, and a raw `mjData` field
+(`{"sim": "act"}`) for the few things mjlab's `EntityData` does not wrap — a muscle
+model's activation state, or the sim time — which a term reads off
+`entity.data.data.<field>`. Anything model-derived and therefore constant is baked into
+the graph instead of becoming a slot.
 
 A handful of values have no simulation slot at all — the previous action, a command's
 current value, a baked constant — so they arrive as **native inputs** the orchestrator

--- a/src/mjswan/compile/parity.py
+++ b/src/mjswan/compile/parity.py
@@ -256,7 +256,10 @@ def run_parity(
                 feeds = {"rand": _to_numpy(rec.rand_vector)}
                 for in_name, slot in zip(export.input_names, export.input_slots):
                     feeds[in_name] = _to_numpy(read_slot(env, slot))
-                onnx_outs = session.run(export.output_names, feeds)
+                # A draw-free event has no `rand` input: the export prunes it.
+                onnx_outs = session.run(
+                    export.output_names, _declared_feeds(session, feeds)
+                )
                 for onnx_out, ref in zip(onnx_outs, ref_tensors):
                     ref_np = _to_numpy(ref)
                     tr.max_abs_diff = max(

--- a/src/mjswan/compile/tracer.py
+++ b/src/mjswan/compile/tracer.py
@@ -47,6 +47,7 @@ def _is_dynamic_field(field_name: str) -> bool:
 #   (entity_name, data_field)        -> env.scene[entity].data.<field>
 #   (_SENSOR_NS, sensor_name)        -> env.scene[sensor].data (a whole BuiltinSensor)
 #   (_COMMAND_NS, "cmd.attr")        -> env.command_manager.get_term(cmd).<attr>
+#   (_SIM_NS, field)                 -> env.scene[entity].data.data.<field> (raw sim data)
 SlotKey = tuple[str, str]
 
 # A tagged key identifies one value an event/command body reads off ``env``. Wider than
@@ -58,6 +59,11 @@ TaggedKey = tuple
 
 _SENSOR_NS = "__sensor__"
 _COMMAND_NS = "__command__"
+_SIM_NS = "__sim__"
+
+#: Env attributes a replay proxy forwards from the real env: trace-time constants a term
+#: may read for shapes or rates. Anything else raises rather than reading a stand-in.
+_FORWARDED_ENV_ATTRS = ("num_envs", "device", "physics_dt", "step_dt", "cfg")
 
 
 def _class_proxy(real: Any, overrides: dict[str, Any]) -> Any:
@@ -104,6 +110,36 @@ def _is_sensor(scene: Any, name: str) -> bool:
 # --- Recording proxy: discovers which env fields a term reads. ---
 
 
+class _RecordingSimData:
+    """Wraps the raw ``SimData`` behind ``Entity.data.data``, logging each field read.
+
+    mjlab's ``EntityData`` wraps most of the sim but not all of it — a muscle model's
+    ``act``, or ``time`` — so a term reads those straight off the sim. The sim is one
+    object shared by every entity, hence its own namespace rather than the entity's.
+    Fields are warp-backed ``TorchArray`` proxies; the tensor view is what gets logged
+    and returned, since the tracer only follows real tensors.
+    """
+
+    def __init__(self, real: Any, log: list[tuple[SlotKey, Any]]):
+        object.__setattr__(self, "_real", real)
+        object.__setattr__(self, "_log", log)
+
+    def __getattr__(self, name: str) -> Any:
+        value = _sim_tensor(getattr(self._real, name))
+        if isinstance(value, torch.Tensor):
+            self._log.append(((_SIM_NS, name), value))
+        return value
+
+
+def _sim_tensor(value: Any) -> Any:
+    """A raw sim field as the tensor it wraps; anything else passes through."""
+    if isinstance(value, torch.Tensor):
+        return value
+    # `TorchArray.__getattr__` delegates to its tensor, so `detach()` is that tensor.
+    detach = getattr(value, "detach", None)
+    return detach() if callable(detach) else value
+
+
 class _RecordingData:
     """Wraps a real ``Entity.data``, logging every field access."""
 
@@ -114,6 +150,8 @@ class _RecordingData:
 
     def __getattr__(self, name: str) -> Any:
         value = getattr(self._real, name)
+        if name == "data":
+            return _RecordingSimData(value, self._log)
         self._log.append(((self._entity, name), value))
         return value
 
@@ -206,7 +244,8 @@ class _RecordingCommandManager:
 
 
 class _RecordingEnv:
-    """Proxy env recording the reads a term makes (entity data, sensors, commands)."""
+    """Proxy env recording the reads a term makes (entity data, sim data, sensors,
+    commands)."""
 
     def __init__(self, real: Any):
         object.__setattr__(self, "_real", real)
@@ -228,12 +267,29 @@ class _RecordingEnv:
 # --- Replay proxy: serves recorded slots to the term during tracing. ---
 
 
+class _ReplaySimData:
+    """Serves recorded raw ``SimData`` fields during the replay pass."""
+
+    def __init__(self, slots: dict[SlotKey, torch.Tensor]):
+        object.__setattr__(self, "_slots", slots)
+
+    def __getattr__(self, name: str) -> torch.Tensor:
+        key = (_SIM_NS, name)
+        if key not in self._slots:
+            raise AttributeError(
+                f"sim field {name!r} was not recorded during discovery"
+            )
+        return self._slots[key]
+
+
 class _ReplayData:
     def __init__(self, entity: str, slots: dict[SlotKey, torch.Tensor]):
         object.__setattr__(self, "_entity", entity)
         object.__setattr__(self, "_slots", slots)
 
-    def __getattr__(self, name: str) -> torch.Tensor:
+    def __getattr__(self, name: str) -> Any:
+        if name == "data":
+            return _ReplaySimData(self._slots)
         key = (self._entity, name)
         try:
             return self._slots[key]
@@ -325,7 +381,7 @@ class _ReplayEnv:
     def __getattr__(self, name: str) -> Any:
         # Forwarded, not copied, so nothing drifts from the real env. Anything else
         # raises rather than silently reading a stand-in.
-        if name in ("num_envs", "device"):
+        if name in _FORWARDED_ENV_ATTRS:
             return getattr(self._real_env, name)
         raise AttributeError(name)
 
@@ -390,8 +446,8 @@ def _classify_slots(
 ) -> bool:
     """Split a recorded read log into graph inputs and baked constants.
 
-    Sensor and command-state reads are live state by definition; an entity data field is
-    dynamic unless it is a model-derived constant. Returns whether *this* log
+    Sensor, command-state and raw sim-data reads are live state by definition; an entity
+    data field is dynamic unless it is a model-derived constant. Returns whether *this* log
     contributed a dynamic slot, which a group's caller needs per term.
     """
     saw_dynamic = False
@@ -399,7 +455,9 @@ def _classify_slots(
         if not isinstance(value, torch.Tensor):
             continue  # non-tensor attribute access, not a graph slot
         namespace, field_name = key
-        if namespace in (_SENSOR_NS, _COMMAND_NS) or _is_dynamic_field(field_name):
+        if namespace in (_SENSOR_NS, _COMMAND_NS, _SIM_NS) or _is_dynamic_field(
+            field_name
+        ):
             dynamic.setdefault(key, value)
             saw_dynamic = True
         else:
@@ -538,6 +596,8 @@ def _slot_input_name(key: SlotKey) -> str:
         return "sensor__" + re.sub(r"\W", "_", name_part)
     if namespace == _COMMAND_NS:
         return "command__" + re.sub(r"\W", "_", name_part)
+    if namespace == _SIM_NS:
+        return f"sim__{name_part}"
     return f"{namespace}__{name_part}"
 
 
@@ -548,16 +608,18 @@ def slot_label(key: SlotKey) -> str:
         return f"sensor:{name_part}"
     if namespace == _COMMAND_NS:
         return f"command:{name_part}"
+    if namespace == _SIM_NS:
+        return f"sim:{name_part}"
     return f"{namespace}.{name_part}"
 
 
 def slot_to_json(key: SlotKey, shape: Sequence[int] | None = None) -> dict[str, Any]:
     """Serialize one input slot for ``policy.json`` / ``config.json``.
 
-    Three shapes, told apart by which keys are present: ``{"entity", "field"}``,
-    ``{"sensor"}``, or ``{"command", "field"}``. All carry ``input`` (the graph input
-    name) and ``shape`` — the runtime feeds a flat array and cannot recover the rank
-    without it.
+    Four shapes, told apart by which keys are present: ``{"entity", "field"}``,
+    ``{"sensor"}``, ``{"command", "field"}``, or ``{"sim"}`` (a whole raw ``mjData``
+    field). All carry ``input`` (the graph input name) and ``shape`` — the runtime
+    feeds a flat array and cannot recover the rank without it.
     """
     namespace, name_part = key
     if namespace == _SENSOR_NS:
@@ -574,6 +636,8 @@ def slot_to_json(key: SlotKey, shape: Sequence[int] | None = None) -> dict[str, 
             "field": attr,
             "input": _slot_input_name(key),
         }
+    elif namespace == _SIM_NS:
+        entry = {"sim": name_part, "input": _slot_input_name(key)}
     else:
         entry = {
             "entity": namespace,
@@ -710,6 +774,8 @@ def read_slot(env: Any, key: SlotKey) -> torch.Tensor:
     if namespace == _COMMAND_NS:
         command_name, _, attr = name_part.partition(".")
         return getattr(env.command_manager.get_term(command_name), attr)
+    if namespace == _SIM_NS:
+        return _sim_tensor(getattr(env.sim.data, name_part))
     return getattr(env.scene[namespace].data, name_part)
 
 
@@ -931,7 +997,7 @@ class _EventReplayEnv:
 
     def __getattr__(self, name: str) -> Any:
         # Forwarded, not defaulted: replay must see the same N discovery ran against.
-        if name in ("num_envs", "device"):
+        if name in _FORWARDED_ENV_ATTRS:
             return getattr(self._real_env, name)
         raise AttributeError(name)
 

--- a/src/mjswan/envs/mdp/actions/actions.py
+++ b/src/mjswan/envs/mdp/actions/actions.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import abc
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     import mujoco
@@ -241,6 +241,11 @@ class JointEffortActionCfg(BaseActionCfg):
         return entry
 
 
+MuscleActionMode = Literal["sigmoid", "direct", "excitation"]
+"""How a muscle term maps a raw action to a control; see
+:class:`MuscleActivationActionCfg`."""
+
+
 @dataclass(kw_only=True)
 class MuscleActivationActionCfg(BaseActionCfg):
     """MyoSuite-style muscle activation control.
@@ -249,17 +254,37 @@ class MuscleActivationActionCfg(BaseActionCfg):
     actuators (``dyntype=muscle``). Both modes apply ``raw = scale * a + offset``
     first, then:
 
-    - ``normalize=True`` (default): applies the canonical MyoSuite sigmoid
-      ``σ(5 * (raw - 0.5))`` to produce excitation in ``(0, 1)``.
-    - ``normalize=False``: clips ``raw`` to ``[0, 1]`` for models that already
-      output excitation in that range.
+    - ``"sigmoid"`` (default): the canonical MyoSuite sigmoid
+      ``σ(5 * (raw - 0.5))``, producing excitation in ``(0, 1)``.
+    - ``"excitation"``: clips ``raw`` to ``[0, 1]`` for models that already output
+      excitation in that range.
+    - ``"direct"``: clips ``raw`` to each actuator's own ``ctrlrange`` and writes it
+      unchanged — checkpoint playback, where the policy was trained against the raw
+      control. A muscle model whose ``ctrlrange`` is ``[-1, 1]`` really does use the
+      negative half, so this is not the same as ``"excitation"``.
 
-    Semantics mirror myosuite4 ``MuscleActionTermCfg.normalize``; see
+    Semantics mirror myosuite4 ``MyoMuscleActivationActionCfg.action_mode``; see
     ``docs/adr/0002-muscle-action-term-aligned-with-myomuscleactivationactioncfg.md``.
     """
 
     normalize: bool = True
-    """Apply the MyoSuite sigmoid mapping. When False, clip ``raw`` to [0, 1]."""
+    """Legacy spelling of ``action_mode``: True is ``"sigmoid"``, False ``"excitation"``.
+    Ignored when ``action_mode`` is set."""
+
+    action_mode: MuscleActionMode | None = None
+    """Named after mjlab/myosuite's own field, so the adapter copies it verbatim."""
+
+    @property
+    def mode(self) -> MuscleActionMode:
+        """The mapping this term applies, with ``normalize`` as the fallback."""
+        if self.action_mode is not None:
+            if self.action_mode not in ("sigmoid", "direct", "excitation"):
+                raise ValueError(
+                    f"MuscleActivationActionCfg.action_mode must be 'sigmoid', "
+                    f"'direct' or 'excitation', got {self.action_mode!r}."
+                )
+            return self.action_mode
+        return "sigmoid" if self.normalize else "excitation"
 
     def to_dict(self) -> dict[str, Any]:
         if self.unsupported_reason is not None:
@@ -270,8 +295,8 @@ class MuscleActivationActionCfg(BaseActionCfg):
             entry["scale"] = self.scale
         if self.offset != 0.0:
             entry["offset"] = self.offset
-        if not self.normalize:
-            entry["normalize"] = False
+        if self.mode != "sigmoid":
+            entry["mode"] = self.mode
         entry["actuator_names"] = list(self.actuator_names)
         self._add_clip(entry)
         return entry

--- a/src/mjswan/scene.py
+++ b/src/mjswan/scene.py
@@ -176,6 +176,17 @@ def _enrich_joint_observations(
             term.params = params
 
 
+def _onnx_output_width(model: onnx.ModelProto) -> int | None:
+    """The last dim of the graph's first output, or ``None`` when it is not static."""
+    if not model.graph.output:
+        return None
+    dims = model.graph.output[0].type.tensor_type.shape.dim
+    if len(dims) < 2:
+        return None
+    width = dims[-1].dim_value
+    return int(width) if width > 0 else None
+
+
 def _default_to_latest(handles: list[PolicyHandle]) -> None:
     """Open the scene on the highest-step checkpoint."""
     if not handles:
@@ -485,6 +496,10 @@ class SceneHandle:
             resolve_pd_gains(
                 adapted_actions, policy_joint_names, self._resolve_env_cfg(env_cfg)
             )
+        if policy_num_actions is None and not policy_joint_names:
+            # A muscle policy has no joint transmission to count; the network's own
+            # output width is the one thing that always knows its action count.
+            policy_num_actions = _onnx_output_width(policy)
 
         policy_config = PolicyConfig(
             name=name,

--- a/src/mjswan/template/src/core/action/__tests__/applyAction.test.ts
+++ b/src/mjswan/template/src/core/action/__tests__/applyAction.test.ts
@@ -42,7 +42,9 @@ function term(over: Partial<ResolvedActionTerm> = {}): ResolvedActionTerm {
     positionActuator: Array(n).fill(true),
     kp: new Float32Array(n),
     kd: new Float32Array(n),
-    muscleNormalize: true,
+    muscleMode: 'sigmoid',
+    muscleCtrlLo: new Float32Array(0),
+    muscleCtrlHi: new Float32Array(0),
     // Unbounded by default: `resolveActionClip` leaves ±Infinity for an unnamed target.
     clipLo: new Float32Array(n).fill(-Infinity),
     clipHi: new Float32Array(n).fill(Infinity),
@@ -161,7 +163,7 @@ describe('applyAction — other kinds', () => {
     const raw = fakeData(2);
     applyAction(
       raw,
-      [term({ controlType: 'muscle_activation', muscleNormalize: true })],
+      [term({ controlType: 'muscle_activation', muscleMode: 'sigmoid' })],
       Float32Array.from([0.5, 10]),
     );
     // σ(5 * (0.5 - 0.5)) = 0.5, and a large excitation saturates toward 1.
@@ -171,10 +173,31 @@ describe('applyAction — other kinds', () => {
     const clipped = fakeData(2);
     applyAction(
       clipped,
-      [term({ controlType: 'muscle_activation', muscleNormalize: false })],
+      [term({ controlType: 'muscle_activation', muscleMode: 'excitation' })],
       Float32Array.from([-3, 10]),
     );
     expect(Array.from(clipped.ctrl)).toEqual([0, 1]);
+  });
+
+  it('direct mode keeps the negative half of the actuator range', () => {
+    // A myosuite muscle model declares ctrlrange="-1 1" and a checkpoint trained
+    // against the raw control really does use the negative half; `excitation` would
+    // clamp it to zero and the policy tracks measurably worse.
+    const data = fakeData(2);
+    applyAction(
+      data,
+      [
+        term({
+          controlType: 'muscle_activation',
+          muscleMode: 'direct',
+          muscleCtrlLo: Float32Array.from([-1, -1]),
+          muscleCtrlHi: Float32Array.from([1, 1]),
+        }),
+      ],
+      Float32Array.from([-0.4, 7]),
+    );
+    expect(data.ctrl[0]).toBeCloseTo(-0.4, 6);
+    expect(data.ctrl[1]).toBeCloseTo(1, 6);
   });
 
   it('leaves ctrl at rest for a kind it does not implement', () => {
@@ -289,7 +312,7 @@ describe('applyAction — clip', () => {
       [
         term({
           controlType: 'muscle_activation',
-          muscleNormalize: false,
+          muscleMode: 'excitation',
           ctrlAdr: [0],
           actionScale: Float32Array.from([1]),
           actionOffset: new Float32Array(1),

--- a/src/mjswan/template/src/core/action/applyAction.ts
+++ b/src/mjswan/template/src/core/action/applyAction.ts
@@ -16,6 +16,13 @@ export type ControlType =
   | 'torque'
   | 'muscle_activation';
 
+/**
+ * How a muscle term maps its raw action, mirroring myosuite's `action_mode`.
+ * `direct` clips to the actuator's own range instead of [0, 1] — a muscle model with
+ * `ctrlrange="-1 1"` uses the negative half, and clamping it away degrades tracking.
+ */
+export type MuscleMode = 'sigmoid' | 'direct' | 'excitation';
+
 /** One resolved action term: the build's descriptor, names already resolved to addresses. */
 export interface ResolvedActionTerm {
   controlType: string;
@@ -42,8 +49,11 @@ export interface ResolvedActionTerm {
   positionActuator: boolean[];
   kp: Float32Array;
   kd: Float32Array;
-  /** `muscle_activation` only: MyoSuite sigmoid when true, else clip to [0, 1]. */
-  muscleNormalize: boolean;
+  /** `muscle_activation` only: how a raw action becomes a control. */
+  muscleMode: MuscleMode;
+  /** `muscle_activation` with `direct`: each actuator's own `ctrlrange`, per joint. */
+  muscleCtrlLo: Float32Array;
+  muscleCtrlHi: Float32Array;
   /**
    * Per-target bounds on the *processed* action (`raw * scale + offset`), `±Infinity`
    * where unbounded. mjlab clamps there, before `joint_position` subtracts the encoder
@@ -87,7 +97,9 @@ function applyActionTerm(
     positionActuator,
     kp,
     kd,
-    muscleNormalize,
+    muscleMode,
+    muscleCtrlLo,
+    muscleCtrlHi,
   } = term;
   const numJoints = ctrlAdr.length;
   const ctrl = mjData.ctrl;
@@ -134,9 +146,10 @@ function applyActionTerm(
   }
 
   if (controlType === 'muscle_activation') {
-    // Shared pre-step: raw = scale * action + offset.
-    // normalize=true:  MyoSuite-canonical sigmoid σ(5 * (raw - 0.5)).
-    // normalize=false: clip(raw, 0, 1) for models that already output excitation.
+    // Shared pre-step: raw = scale * action + offset, then per `muscleMode`:
+    //   sigmoid:    MyoSuite-canonical σ(5 * (raw - 0.5)).
+    //   direct:     clip to the actuator's own ctrlrange, written unchanged.
+    //   excitation: clip(raw, 0, 1) for models that already output excitation.
     for (let i = 0; i < numJoints; i++) {
       const ctrlIndex = ctrlAdr[i];
       if (ctrlIndex < 0) continue;
@@ -146,9 +159,12 @@ function applyActionTerm(
         term.clipLo[i],
         term.clipHi[i],
       );
-      ctrl[ctrlIndex] = muscleNormalize
-        ? 1 / (1 + Math.exp(-5 * (raw - 0.5)))
-        : clamp01(raw);
+      ctrl[ctrlIndex] =
+        muscleMode === 'sigmoid'
+          ? 1 / (1 + Math.exp(-5 * (raw - 0.5)))
+          : muscleMode === 'direct'
+            ? clamp(raw, muscleCtrlLo[i] ?? -1, muscleCtrlHi[i] ?? 1)
+            : clamp01(raw);
     }
   }
 }

--- a/src/mjswan/template/src/core/engine/runtime.ts
+++ b/src/mjswan/template/src/core/engine/runtime.ts
@@ -35,6 +35,7 @@ import {
   resolveActionClip,
   stepPhysics,
   type ResolvedActionTerm,
+  type MuscleMode,
 } from '../action/applyAction';
 import { applyResetTerms } from './resetChain';
 import { Observations } from '../observation/observations';
@@ -61,6 +62,15 @@ import { SeededRng } from '../rng';
 const DEFAULT_TERM_SEED = 0x5eed;
 
 const EMPTY_ACTIONS = new Float32Array(0);
+/** Only the `direct` muscle mode reads an actuator range; the rest carry none. */
+const EMPTY_CTRL_RANGE = new Float32Array(0);
+
+/** A muscle term's mode, falling back to the pre-`mode` `normalize` flag. */
+function readMuscleMode(term: Record<string, unknown>): MuscleMode {
+  const mode = term.mode;
+  if (mode === 'sigmoid' || mode === 'direct' || mode === 'excitation') return mode;
+  return term.normalize === false ? 'excitation' : 'sigmoid';
+}
 
 /** Only for a policy-less scene; a policy carries its own rate in `controlDt`. */
 const DEFAULT_VIEWER_CONTROL_DT = 0.02;
@@ -1125,7 +1135,9 @@ export class mjswanRuntime {
         positionActuator,
         kp,
         kd,
-        muscleNormalize: false,
+        muscleMode: 'sigmoid' as MuscleMode,
+        muscleCtrlLo: EMPTY_CTRL_RANGE,
+        muscleCtrlHi: EMPTY_CTRL_RANGE,
         clipLo,
         clipHi,
       };
@@ -1194,9 +1206,18 @@ export class mjswanRuntime {
           n,
           0.0
         );
-        const muscleNormalize = (actionTerm as { normalize?: boolean }).normalize ?? true;
+        const muscleMode = readMuscleMode(actionTerm as Record<string, unknown>);
+        // `direct` writes the raw action, so it needs each actuator's own range.
+        const ctrlRange = this.mjModel?.actuator_ctrlrange;
+        const ctrlLoRange = new Float32Array(n);
+        const ctrlHiRange = new Float32Array(n);
+        for (let i = 0; i < n; i++) {
+          const adr = muscleMapping.ctrlAdr[i];
+          ctrlLoRange[i] = ctrlRange?.[2 * adr] ?? -1;
+          ctrlHiRange[i] = ctrlRange?.[2 * adr + 1] ?? 1;
+        }
         console.log(
-          `[PolicyRunner] Action term "${termKey}" (muscle_activation): ${n} actuator(s), normalize=${muscleNormalize}`
+          `[PolicyRunner] Action term "${termKey}" (muscle_activation): ${n} actuator(s), mode=${muscleMode}`
         );
         results.push({
           controlType,
@@ -1211,7 +1232,9 @@ export class mjswanRuntime {
           positionActuator: new Array(n).fill(false),
           kp: new Float32Array(n),
           kd: new Float32Array(n),
-          muscleNormalize,
+          muscleMode,
+          muscleCtrlLo: ctrlLoRange,
+          muscleCtrlHi: ctrlHiRange,
           ...resolveActionClip(
             actionTerm.clip as Record<string, readonly number[]> | undefined,
             muscleMapping.ctrlAdr.map((_, i) => patterns[i] ?? ''),

--- a/src/mjswan/template/src/core/onnx/__tests__/slotReader.test.ts
+++ b/src/mjswan/template/src/core/onnx/__tests__/slotReader.test.ts
@@ -320,6 +320,27 @@ describe('createSlotReader — command state slots', () => {
   });
 });
 
+describe('createSlotReader — sim slots', () => {
+  it('serves a whole raw mjData array as float32', () => {
+    const { mjModel, mjData } = fakeScene();
+    mjData.act = Float64Array.from([0.25, 0.5, 0.75]);
+    const read = createSlotReader(() => ({ mjModel, mjData }) as unknown as SlotReaderContext);
+    close(read({ sim: 'act' }), [0.25, 0.5, 0.75]);
+  });
+
+  it('wraps a scalar field such as time in a one-element array', () => {
+    const { mjModel, mjData } = fakeScene();
+    mjData.time = 1.25;
+    const read = createSlotReader(() => ({ mjModel, mjData }) as unknown as SlotReaderContext);
+    close(read({ sim: 'time' }), [1.25]);
+  });
+
+  it('returns null for a field mjData does not carry', () => {
+    const read = createSlotReader(() => context());
+    expect(read({ sim: 'no_such_field' })).toBeNull();
+  });
+});
+
 describe('slotDims', () => {
   it('rebuilds the traced rank with batch pinned to 1', () => {
     // site_pos_w is (batch, num_sites, 3) — feeding (1, 6) would be rejected.

--- a/src/mjswan/template/src/core/onnx/session.ts
+++ b/src/mjswan/template/src/core/onnx/session.ts
@@ -34,6 +34,8 @@ export interface OnnxInputSlot {
   field?: string;
   sensor?: string;
   command?: string;
+  /** A raw `mjData` field the term read off mjlab's `SimData` (`act`, `time`, ...). */
+  sim?: string;
   input?: string;
   shape?: number[];
 }

--- a/src/mjswan/template/src/core/onnx/slotReader.ts
+++ b/src/mjswan/template/src/core/onnx/slotReader.ts
@@ -10,6 +10,10 @@
  * Entities resolve by the `name/` prefix mjlab's `attach` adds; an unprefixed model
  * falls back to the whole model, which is correct because such a scene is
  * single-entity. An unknown field returns null and the caller holds its previous value.
+ *
+ * A `sim` slot is a raw `mjData` field mjlab's `EntityData` does not wrap (`act`,
+ * `time`), read whole: mjlab's `SimData` is the entire sim too, so the graph carries
+ * whatever indexing the term did.
  */
 
 import { quatApply, quatApplyInv } from '../observation/math';
@@ -265,6 +269,16 @@ export function isReadableEntityField(field: string): boolean {
   return field in FIELD_READERS;
 }
 
+/** A whole raw `mjData` field as float32, or null when `mjData` has no such array. */
+export function readSimField(mjData: MjData, field: string): Float32Array | null {
+  const value = (mjData as unknown as Record<string, unknown>)[field];
+  if (typeof value === 'number') return new Float32Array([value]);
+  if (value && typeof (value as ArrayLike<number>).length === 'number') {
+    return Float32Array.from(value as ArrayLike<number>);
+  }
+  return null;
+}
+
 /**
  * A named MuJoCo sensor's `sensordata` window. The build records mjlab's prefixed name
  * (`robot/imu_lin_vel`), while a plain-MJCF model has the bare one, so try both.
@@ -364,6 +378,8 @@ export function createSlotReader(
 
     const { mjModel, mjData } = context;
     if (!mjModel || !mjData) return null;
+
+    if (slot.sim) return readSimField(mjData, slot.sim);
 
     if (slot.sensor) {
       if (slot.field) {

--- a/src/mjswan/trace_env.py
+++ b/src/mjswan/trace_env.py
@@ -31,7 +31,8 @@ def _quiet_warp_module_loads() -> None:
     """
     import warp
 
-    if warp.config.log_level == warp.LOG_INFO:
+    # warp 1.12 has no `log_level`; its module loads are quiet by default.
+    if getattr(warp.config, "log_level", None) == getattr(warp, "LOG_INFO", object()):
         warp.config.log_level = warp.LOG_WARNING
 
 

--- a/tests/test_muscle_action.py
+++ b/tests/test_muscle_action.py
@@ -133,15 +133,15 @@ class TestSerialization:
         d = cfg.to_dict()
         assert d["offset"] == -0.5
 
-    def test_normalize_false_emitted(self):
+    def test_normalize_false_emitted_as_a_mode(self):
         cfg = MuscleActivationActionCfg(actuator_names=("m1",), normalize=False)
         d = cfg.to_dict()
-        assert d["normalize"] is False
+        assert d["mode"] == "excitation"
 
     def test_normalize_true_omitted(self):
         cfg = MuscleActivationActionCfg(actuator_names=("m1",), normalize=True)
         d = cfg.to_dict()
-        assert "normalize" not in d
+        assert "mode" not in d and "normalize" not in d
 
     def test_actuator_names_tuple_serialized_as_list(self):
         cfg = MuscleActivationActionCfg(actuator_names=("a", "b", "c"))
@@ -351,7 +351,7 @@ class TestBuilderMuscleRoundTrip:
         assert data["actions"]["muscles"]["type"] == "muscle_activation"
         assert data["actions"]["muscles"]["actuator_names"] == ["m1", "m2"]
 
-    def test_normalize_false_serialized_in_policy_json(
+    def test_muscle_mode_serialized_in_policy_json(
         self, tmp_path, muscle_model, minimal_onnx
     ):
         builder = Builder()
@@ -373,4 +373,34 @@ class TestBuilderMuscleRoundTrip:
                 tmp_path / "out" / "main" / "assets" / name2id("S") / "policy.json"
             ).read_text()
         )
-        assert data["actions"]["muscles"]["normalize"] is False
+        assert data["actions"]["muscles"]["mode"] == "excitation"
+
+
+class TestMuscleActionMode:
+    """``action_mode``, which mjlab/myosuite spells the same way so the adapter copies it."""
+
+    def test_legacy_normalize_maps_onto_the_two_named_modes(self):
+        assert MuscleActivationActionCfg(actuator_names=("m1",)).mode == "sigmoid"
+        assert (
+            MuscleActivationActionCfg(actuator_names=("m1",), normalize=False).mode
+            == "excitation"
+        )
+
+    def test_action_mode_wins_over_normalize(self):
+        cfg = MuscleActivationActionCfg(
+            actuator_names=("m1",), normalize=True, action_mode="direct"
+        )
+        assert cfg.mode == "direct"
+
+    def test_only_the_default_mode_is_left_out_of_the_json(self):
+        assert "mode" not in MuscleActivationActionCfg(actuator_names=("m1",)).to_dict()
+        for mode in ("direct", "excitation"):
+            entry = MuscleActivationActionCfg(
+                actuator_names=("m1",), action_mode=mode
+            ).to_dict()
+            assert entry["mode"] == mode
+
+    def test_an_unknown_mode_is_rejected(self):
+        cfg = MuscleActivationActionCfg(actuator_names=("m1",), action_mode="clamp")
+        with pytest.raises(ValueError, match="action_mode"):
+            _ = cfg.mode

--- a/tests/test_sim_slot.py
+++ b/tests/test_sim_slot.py
@@ -1,0 +1,100 @@
+"""Raw ``SimData`` fields as traced-graph slots.
+
+Layer: L3 (builds a real mjlab env from a spec).
+
+mjlab's ``EntityData`` wraps most of the sim, but not a muscle model's activation state
+(``act``) or the sim ``time``; a task that needs them reads ``entity.data.data.<field>``
+(myosuite's mimic terms do exactly this). Those fields must become graph inputs in
+their own ``sim`` namespace, served whole by the browser from ``mjData``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("MUJOCO_GL", "disable")
+
+pytest.importorskip("mjlab")
+pytest.importorskip("onnxruntime")
+torch = pytest.importorskip("torch")
+
+import mujoco  # noqa: E402
+import numpy as np  # noqa: E402
+import onnxruntime as ort  # noqa: E402
+
+from mjswan.compile.tracer import (  # noqa: E402
+    read_slot,
+    slots_json,
+    trace_term,
+)
+from mjswan.trace_env import build_single_entity_trace_env  # noqa: E402
+
+MUSCLE_MODEL = """
+<mujoco>
+  <worldbody>
+    <body name="base" pos="0 0 1">
+      <freejoint/>
+      <geom type="box" size="0.1 0.1 0.1"/>
+      <site name="s_a" pos="0 0 0.1"/>
+      <body name="link" pos="0 0 0.3">
+        <joint name="hinge" type="hinge" axis="0 1 0"/>
+        <geom type="box" size="0.05 0.05 0.1"/>
+        <site name="s_b" pos="0 0 -0.1"/>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <spatial name="t"><site site="s_a"/><site site="s_b"/></spatial>
+  </tendon>
+  <actuator>
+    <muscle name="m" tendon="t" lengthrange="0 1"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _spec():
+    return mujoco.MjSpec.from_string(MUSCLE_MODEL)
+
+
+@pytest.fixture(scope="module")
+def env():
+    return build_single_entity_trace_env(_spec)
+
+
+def _act_scaled_by_step(env):
+    """A myosuite-shaped term: raw ``act`` scaled by the control rate."""
+    data = env.scene["robot"].data.data
+    return data.act * (env.physics_dt * env.cfg.decimation)
+
+
+def _time(env):
+    return torch.as_tensor(env.scene["robot"].data.data.time).reshape(-1, 1)
+
+
+def test_raw_sim_fields_become_sim_slots(env):
+    export = trace_term(_act_scaled_by_step, {}, env, name="act")
+    assert export.input_slots == [("__sim__", "act")]
+    assert slots_json(export) == [
+        {"sim": "act", "input": "sim__act", "shape": [1, 1]},
+    ]
+
+
+def test_graph_matches_the_live_term_on_a_fresh_value(env):
+    export = trace_term(_act_scaled_by_step, {}, env, name="act")
+    session = ort.InferenceSession(
+        export.onnx_bytes, providers=["CPUExecutionProvider"]
+    )
+    # Move the sim off the trace-time value: a baked constant would not follow.
+    env.scene["robot"].data.data.act[:] = 0.7
+    feeds = {export.input_names[0]: read_slot(env, export.input_slots[0]).numpy()}
+    (out,) = session.run([export.output_name], feeds)
+    np.testing.assert_allclose(out, _act_scaled_by_step(env).numpy(), rtol=1e-6)
+    assert out[0, 0] == pytest.approx(0.7 * env.physics_dt * env.cfg.decimation)
+
+
+def test_sim_time_is_a_dynamic_slot(env):
+    export = trace_term(_time, {}, env, name="time")
+    assert export.input_slots == [("__sim__", "time")]


### PR DESCRIPTION
## Motivation

Porting myosuite's `myoMimicFullbody-v0` with the mjlab-to-mjswan skill exposed a
structural limit, not a missing feature.

A traced term reads simulation state through **slots**. Today a slot is the *value an
`EntityData` property returned*, and the browser reproduces that property's math in
TypeScript. `FIELD_READERS` implements **15 of mjlab's 55 properties**. The other 40 are
not merely unavailable: nothing validates a slot at build time, so a term reading one
**builds fine**, and in the browser `OnnxObservation` logs a `console.warn` and
`return this.last` — the whole observation group freezes at its previous value. A policy
runs happily on stale state.

myosuite goes further and reads the raw sim directly (`mimic_mjlab_env.py` does
`entity.data.data.<field>` in 23 places — `qpos` ×6, `time` ×3, `qvel` ×2, `act` ×2).
That is mjlab's own public API (`EntityData.data: mjwarp.Data`), not a patch, and on
`main` every such term fails to trace with a misleading `UntraceableTerm` about
input-dependent control flow.

This PR inverts the foundation: **raw `mjData` is what a slot is**, mjlab's property math
is traced into the graph, and the TypeScript readers become an optional fast path.

## What changes

### 1. Raw sim data as the slot foundation

- **`sim` slot namespace** (`compile/tracer.py`): the recording and replay proxies follow
  `.data` into the raw `SimData`, log each field read as `("__sim__", field)` (always
  dynamic), and serialize it as `{"sim": field, "input": "sim__field", "shape": [...]}`.
  `read_slot` serves it from `env.sim.data`.
- **Trace-through for `EntityData` properties.** `_ReplayData` stops returning a recorded
  value per field. Instead it hands the term a real `EntityData` whose `data` field is
  swapped for the replay sim proxy:

  ```python
  replay = copy.copy(entity.data)
  object.__setattr__(replay, "data", _ReplaySimData(slots))
  replay.joint_pos   # -> gather(qpos_slot, const_adr) enters the graph
  ```

  `EntityData` is a plain `@dataclass` and `data` is an ordinary field, so this needs no
  mjlab change. `indexing` stays real and bakes as a model-derived constant, as do tensor
  fields (`encoder_bias`, `forward_vec_b`, `gravity_vec_w`).
- **All 55 properties are traceable.** No property body calls `mujoco.` / `mjwarp.` /
  `warp.` (those names appear only in type annotations); every one is pure torch. There is
  no tensor-valued control flow either — batching over `num_envs` makes a Python `if` on a
  tensor unwritable, which is why mjlab already uses `torch.where` cascades
  (`envs/mdp/dr/geom.py`). The two non-torch things found are `assert body_iquat is not
  None` (a `None` check, folds at trace time) and `joint_torques`, which raises
  `NotImplementedError` today and will keep doing so.
- **Failure mode changes from silent to loud.** A property the engine cannot serve used to
  build and then freeze the observation. Now an untraceable property fails the build.

### 2. Entity-field readers as a shortcut, all 55

Moving the math into the graph costs ONNX nodes. Measured on G1's five standard
observation terms, exported the way the tracer does (`dynamo=False`, opset 17):

| | value-passing | raw-passing |
|---|---:|---:|
| graph nodes | 1 | 361 |
| of those `Constant` (ORT folds them) | 0 | 214 |
| **executed per step** | **1** (`Concat`) | **147** |

The 147 are `Slice` 63, `Concat` 30, `Mul` 21, `Sub` 12, `Reshape` 7, `Gather` 6, `Add` 4,
other 4. **93 of them are `Slice`/`Concat`** — `quat_apply_inverse` decomposed
element-wise, which TypeScript does with array indexing for free. ORT Web runs
single-threaded (`ort.env.wasm.numThreads = 1`, `proxy = false`) with every inference
serialized, so this does not move off the critical path; `FusedObservation`'s own header
says the fixed per-call cost is the whole expense for graphs this small.

So the readers stay, as a **shortcut over the raw foundation** rather than the foundation
itself. The difference from today is the fallback: a property with no reader is served by
the traced path instead of freezing the observation.

All 55 are implemented, for predictability rather than need — mjlab's MDP terms read only
14 (6 of them unimplemented today: `actuator_force`, `body_com_pos_w`, `body_com_quat_w`,
`body_external_wrench`, `joint_acc`, `qfrc_actuator`) and the playground's five tasks read
four, all already present.

**File layout**, mirroring `mjlab/entity/data.py`'s own sections so a mjlab bump maps to a
file:

```
core/onnx/slotReader/
  index.ts          slot dispatch (sim / entity / sensor / command)
  indexing.ts       EntityIndex resolution (qposAdr, siteIds, ...)
  fields/
    index.ts        assembles FIELD_READERS
    root.ts     16  "Root properties" + "Pose and velocity component accessors"
    body.ts     15  "Body properties"
    site.ts      6  "Site properties"
    geom.ts      6  "Geom properties"
    joint.ts     5  "Joint properties"
    forces.ts    3  "Generalized forces" + actuator_force
    tendon.ts    2  "Tendon properties"
    derived.ts   2  projected_gravity_b, heading_w
```

Quaternion helpers come from the existing `core/observation/math.ts`, as mjlab keeps them
in `utils/lab_api/math.py`.

### 3. Index-narrowed sim slots

A raw slot is served whole because the graph's baked indices address the full array.
`site_xmat` on the myosuite model is 2038 sites × 9 = 18,342 floats per step to read 17
sites. Measured per control step:

| | G1 (5 terms) | musclemimic (13 slots) |
|---|---:|---:|
| value-passing | 67 | n/a (does not build) |
| raw, whole field | 583 | 27,644 (108 KiB) |
| raw, narrowed | 74 | ~2,300 |

The manifest carries the rows, and the graph stops carrying the gather:

```jsonc
// before
{ "sim": "cvel", "input": "sim__cvel", "shape": [1, 102, 6] }
// graph: Gather(sim__cvel, [1, 4, 7, ...17 ids], axis=1)

// after
{ "sim": "cvel", "input": "sim__cvel", "shape": [1, 17, 6], "rows": [1, 4, 7, ...] }
// graph: no Gather — the input is already those 17 rows, in order
```

**Derive the rows during discovery, not by rewriting the exported graph.** `_RecordingSimData`
already returns the tensor behind each raw field; have it return an index-recording tensor
so `qpos[:, adr]` captures `adr` in place. The replay pass then hands the term a tensor
already narrowed to those rows, the math naturally indexes `0..n-1`, and no `Gather` is
ever emitted. This avoids ONNX graph surgery and its pattern-matching gaps.

Points to settle in implementation:

- Several terms may index the same field with different sets (`cvel` by root body in one
  term, by 17 site parents in another): take the union and renumber once per field.
- Slices (`qpos[:, 2:]`, a sensor window) narrow as ranges; an index computed from data
  cannot narrow.
- **When rows cannot be determined, emit the whole field.** Narrowing is per slot, not
  all-or-nothing, so partial coverage is correct and shippable.

### 4. Document format 2

`sim` slots and `rows` are structure a format-1 reader accepts and then misreads — the
slot read returns `null` and `OnnxObservation` freezes the group. That is exactly the
break `format` exists for (`document.py`: "only when an engine reading the old structure
would misread the new one").

- `DOCUMENT_FORMAT` 1 → 2 (`src/mjswan/document.py`)
- `MAX_DOCUMENT_FORMAT` 1 → 2 (`template/src/manifest/index.ts`)

The engine-side guard is a ceiling, so the new engine still reads format 1.

> **Follow-up in mjswan-cloud, not this PR.** `ENGINE_DOCUMENT_FORMAT` maps one format per
> engine version and matches exactly ("never 'at least'"). A new row of `2` means format-1
> documents stop being offered the new engine, even though it reads them. That table needs
> a decision.

### 5. `MuscleActivationActionCfg.action_mode`

Unchanged from this PR's original scope. myosuite's `MyoMuscleActivationActionCfg` has
three modes; `normalize: bool` covered two. The missing one, `direct`, writes the raw
action clipped to each actuator's own `ctrlrange`.

A myosuite muscle model declares `ctrlrange="-1 1"`, and the public MuscleMimic checkpoint
puts **54.7% of its 354 outputs (194 muscles) below zero every step**; `clamp(raw, 0, 1)`
discards **76.8% of the action magnitude** and writes those 194 controls as exactly 0.
Measured on `myoMimicFullbody-v0`:

| muscle mode | mean site error | episode |
|---|---|---|
| `excitation` (clip to `[0, 1]`) | 0.186 m | resets every 3.06 s |
| `direct` (clip to `ctrlrange`) | 0.095 m | no deviation trip in 4 s |

The field is named as mjlab/myosuite spells it, so `_adapt_action_cfg`'s name-matching
field copy carries it across with nothing at the call site — without that name, every
adapted myosuite muscle task silently falls back to `sigmoid`. `normalize` stays as the
legacy spelling; `policy.json` carries `mode`, and the engine reads either.

### 6. Carried over

- Replay proxies forward `physics_dt` / `step_dt` / `cfg` alongside `num_envs` / `device`.
- `add_policy` fills `policy_num_actions` from the ONNX output width when a policy has no
  joint names (muscle policies).
- warp 1.12 compatibility in `_quiet_warp_module_loads`.
- Parity: a draw-free event has its `rand` input pruned by the export, so feeds go through
  `_declared_feeds`.

## Sequencing

1. **Rebase onto `main` first, as its own step.** This branch forks at `0d2119ec` (PR #108)
   and `main` is 80 commits ahead, including the `config.json` → `manifest.json` move
   (ADR 0006) that introduced `format` and `MAX_DOCUMENT_FORMAT`. Everything above assumes
   the post-rebase tree.
2. `sim` namespace + trace-through (§1), with the existing 15 readers kept as-is.
3. The remaining 40 readers and the file split (§2).
4. Row narrowing (§3).
5. Format bump (§4) — last, once the manifest shape is final.

## Verification

- `tests/test_sim_slot.py`: trace a term reading `data.data.act` and `time`, run it in ORT
  against a changed value.
- **New:** trace a term reading an `EntityData` property, and assert the graph reproduces
  mjlab's property over stepped state — this is what moves the property math into
  `parity.py`'s scope, where today it is checked only by the fixture.
- **New:** assert the shortcut and the traced path agree. `parity.py` gives traced ≡ mjlab
  and `slotReaderParity.test.ts` gives reader ≡ mjlab, so transitively reader ≡ traced; add
  the assertion that both paths are exercised for a property that has a reader.
- `dump_slot_fixture.py` + `slotReaderParity.test.ts`: extend to all 55. The two current
  tasks (`Mjlab-Lift-Cube-Yam`, `Mjlab-Velocity-Flat-Unitree-G1`) do not touch every
  property, so the fixture needs tasks that do, or synthetic entities that expose them. The
  coverage assertion must keep failing on an unchecked reader.
- **New:** a narrowed slot feeds the same numbers as the whole field (§3), and a field that
  cannot be narrowed still ships whole.
- `tests/test_muscle_action.py`, `applyAction.test.ts`: unchanged.
- End to end on the myosuite port: 10 mjlab observation terms, `mimic_deviation` and the
  reset event trace with max |Δ| = 0 over 16 steps; the upstream 2418-wide observation and
  its termination at 2.4e-07 and 0.
- `make format`, `make type`, `pytest -m "not slow"`, `vitest`, eslint.

## Not covered

- Event and command tracing does not follow `.data.data` reads (the `_EvRec*` tagged-key
  proxies are unchanged); the port's reset event reads no sim state.
- Wall-clock in a browser is unmeasured. The node counts above are static; the one
  empirical anchor is that musclemimic's observation graph is **429 nodes (231 non-`Constant`)
  and runs at 100 Hz**, with its termination at 65 and its reset event at 4. A per-step
  breakdown — physics, observation graph, policy network, copy — is worth having and would
  tell us whether the shortcut earns its place.
- ORT threading is not touched. `numThreads` is load-bearing for the inlined-loader
  strategy, and neither it nor `proxy` addresses per-node dispatch: threads parallelize
  within an op and there is nothing to split in a 3-element tensor, while `proxy` adds a
  round trip per `run()` to a design that runs many small graphs serially.
- `ENGINE_DOCUMENT_FORMAT` in mjswan-cloud (see §4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
