### PR TITLE
Model the action term's own state in the browser

### DIFF
--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -269,7 +269,7 @@ def _native_size(
 ) -> int | None:
     """Declared width for a native term, or ``None`` if it isn't native."""
     func_name = getattr(term_cfg.func, "__name__", None)
-    if func_name == "last_action":
+    if func_name in ("last_action", "action_history"):
         # The whole vector; a term-scoped one needs `action_offset` for its slice.
         if term_cfg.params.get("action_name") is not None:
             return None

--- a/src/mjswan/compile/tracer.py
+++ b/src/mjswan/compile/tracer.py
@@ -34,6 +34,9 @@ _STATIC_DATA_FIELDS: frozenset[str] = frozenset(
         "soft_joint_vel_limits",
         "joint_effort_limits",
         "soft_joint_effort_limits",
+        # Randomizable in mjlab, but the browser's action layer already holds one
+        # build-time vector for it, so baking is what keeps the two agreeing.
+        "encoder_bias",
     }
 )
 
@@ -1432,6 +1435,7 @@ def trace_command_term(
 # since the runtime already holds these values every frame.
 NATIVE_OBSERVATION_FUNCS: dict[str, str] = {
     "last_action": "prev_action",
+    "action_history": "prev_action",
     "generated_commands": "command",
 }
 
@@ -1456,7 +1460,11 @@ def native_observation_entry(
     entry: dict[str, Any] = {"name": name, "native": kind}
     if kind == "command":
         entry["command_name"] = params["command_name"]
-    elif params.get("action_name") is not None:
+        return entry
+    # How far back in the action window, `last_action`'s 0 being the newest.
+    if params.get("age"):
+        entry["age"] = int(params["age"])
+    if params.get("action_name") is not None:
         entry["action_name"] = params["action_name"]
         entry["action_offset"] = action_term_offset(env, params["action_name"])
     return entry

--- a/src/mjswan/envs/mdp/actions/actions.py
+++ b/src/mjswan/envs/mdp/actions/actions.py
@@ -126,9 +126,27 @@ class JointPositionActionCfg(BaseActionCfg):
     mapping joint names (must match ``policy_joint_names``) to values.
     Only used by the TS runtime for motor actuators with external PD."""
 
+    ema_alpha: float | None = None
+    """Exponential-moving-average factor on the processed target, in ``(0, 1]``.
+
+    ``target = alpha * processed + (1 - alpha) * previous_target``, advanced once per
+    control step — not per physics substep. ``None`` (or ``1.0``) is no smoothing."""
+
+    warmup_time_s: float | None = None
+    """Seconds at the start of an episode during which the default pose is held.
+
+    Rounded up to whole control steps, matching mjlab's
+    ``episode_length_buf * step_dt < warmup_time_s``. ``None`` is no warmup."""
+
     def to_dict(self) -> dict[str, Any]:
         if self.unsupported_reason is not None:
             raise NotImplementedError(self.unsupported_reason)
+        if self.ema_alpha is not None and not 0.0 < self.ema_alpha <= 1.0:
+            raise ValueError(f"ema_alpha must be in (0, 1], got {self.ema_alpha}")
+        if self.warmup_time_s is not None and self.warmup_time_s < 0.0:
+            raise ValueError(
+                f"warmup_time_s must be non-negative, got {self.warmup_time_s}"
+            )
 
         entry: dict[str, Any] = {"type": "joint_position"}
         if self.scale != 1.0:
@@ -141,6 +159,10 @@ class JointPositionActionCfg(BaseActionCfg):
             entry["stiffness"] = self.stiffness
         if self.damping is not None:
             entry["damping"] = self.damping
+        if self.ema_alpha is not None and self.ema_alpha != 1.0:
+            entry["ema_alpha"] = self.ema_alpha
+        if self.warmup_time_s:
+            entry["warmup_time_s"] = self.warmup_time_s
         self._add_clip(entry)
         return entry
 

--- a/src/mjswan/envs/mdp/observations.py
+++ b/src/mjswan/envs/mdp/observations.py
@@ -1,8 +1,9 @@
 """Custom observation registry.
 
 mjswan reimplements none of mjlab's observation functions: a task's real function
-object is traced to ONNX at build time. This module carries only the
-``ObservationBinding`` escape hatch, for a term that cannot be traced at all.
+object is traced to ONNX at build time. This module carries the ``ObservationBinding``
+escape hatch, for a term that cannot be traced at all, plus :func:`action_history` —
+env-level state the runtime already holds, so no graph is traced for it either.
 """
 
 from __future__ import annotations
@@ -60,8 +61,40 @@ def register_observation(
     _custom_registry[mjlab_name] = sentinel
 
 
+def action_history(env: Any, age: int = 1, action_name: str | None = None) -> Any:
+    """The raw policy action from *age* control steps back.
+
+    mjlab's ``ActionManager`` keeps a three-deep window — ``action``, ``prev_action``,
+    ``prev_prev_action`` — and a task observing action history reads the older two
+    directly, where mjlab's own ``last_action`` only ever returns the newest. The
+    browser holds the same window, so like ``last_action`` this needs no graph.
+
+    ``age=0`` is ``last_action``. Point a task's own term at this with
+    ``term_cfg.func = action_history`` and ``params={"age": 1}``.
+    """
+    manager = env.action_manager
+    fields = ("action", "prev_action", "prev_prev_action")
+    if not 0 <= age < len(fields):
+        raise ValueError(f"age must be one of {tuple(range(len(fields)))}, got {age}")
+    actions = getattr(manager, fields[age])
+    if action_name is None:
+        return actions
+    offset = 0
+    for term_name, dim in zip(
+        manager.active_terms, manager.action_term_dim, strict=True
+    ):
+        if term_name == action_name:
+            return actions[:, offset : offset + int(dim)]
+        offset += int(dim)
+    raise ValueError(
+        f"action_history(action_name={action_name!r}) names an action term the scene "
+        f"does not define. Available: {', '.join(manager.active_terms) or '(none)'}."
+    )
+
+
 __all__ = [
     "ObservationBinding",
+    "action_history",
     "register_observation",
     "_custom_registry",
 ]

--- a/src/mjswan/template/src/core/action/__tests__/applyAction.test.ts
+++ b/src/mjswan/template/src/core/action/__tests__/applyAction.test.ts
@@ -8,8 +8,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  advanceActionSmoothing,
   applyAction,
   clampActions,
+  resetActionSmoothing,
   readClipActions,
   resolveActionClip,
   stepPhysics,
@@ -46,6 +48,8 @@ function term(over: Partial<ResolvedActionTerm> = {}): ResolvedActionTerm {
     // Unbounded by default: `resolveActionClip` leaves ±Infinity for an unnamed target.
     clipLo: new Float32Array(n).fill(-Infinity),
     clipHi: new Float32Array(n).fill(Infinity),
+    emaAlpha: 1,
+    warmupSteps: 0,
     ...over,
   };
 }
@@ -383,5 +387,71 @@ describe('readClipActions / clampActions', () => {
     expect(readClipActions(-1)).toBeNull();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+describe('applyAction — EMA smoothing and warmup', () => {
+  /** One control step: advance the filter, then write ctrl as the substeps would. */
+  function controlStep(t: ResolvedActionTerm, actions: number[]): number[] {
+    const data = fakeData(t.ctrlAdr.length);
+    const vector = Float32Array.from(actions);
+    advanceActionSmoothing([t], vector);
+    applyAction(data, [t], vector);
+    return Array.from(data.ctrl);
+  }
+
+  it('approaches the raw target geometrically', () => {
+    const t = term({ emaAlpha: 0.5, defaultJointPos: new Float32Array(2) });
+    expect(controlStep(t, [1, 1])).toEqual([0.5, 0.5]);
+    expect(controlStep(t, [1, 1])).toEqual([0.75, 0.75]);
+    expect(controlStep(t, [1, 1])).toEqual([0.875, 0.875]);
+  });
+
+  it('is a pass-through at alpha = 1', () => {
+    const t = term({ emaAlpha: 1 });
+    expect(controlStep(t, [0.25, -0.5])).toEqual([0.25, -0.5]);
+  });
+
+  it('holds the default pose for exactly warmupSteps control steps', () => {
+    const t = term({
+      emaAlpha: 1,
+      warmupSteps: 2,
+      defaultJointPos: Float32Array.from([0.5, 0.5]),
+    });
+    expect(controlStep(t, [1, 1])).toEqual([0.5, 0.5]);
+    expect(controlStep(t, [1, 1])).toEqual([0.5, 0.5]);
+    expect(controlStep(t, [1, 1])).toEqual([1.5, 1.5]);
+  });
+
+  it('advances once per control step, not once per substep', () => {
+    const t = term({ emaAlpha: 0.5, defaultJointPos: new Float32Array(2) });
+    const data = fakeData(2);
+    const actions = Float32Array.from([1, 1]);
+    advanceActionSmoothing([t], actions);
+    const mujoco = { mj_step: vi.fn() };
+    stepPhysics(mujoco, {} as never, data, [t], actions, 4);
+    expect(mujoco.mj_step).toHaveBeenCalledTimes(4);
+    expect(Array.from(data.ctrl)).toEqual([0.5, 0.5]);
+  });
+
+  it('returns to the default pose and re-arms warmup on reset', () => {
+    const t = term({
+      emaAlpha: 0.5,
+      warmupSteps: 1,
+      defaultJointPos: Float32Array.from([0.5, 0.5]),
+    });
+    controlStep(t, [1, 1]);
+    controlStep(t, [1, 1]);
+    resetActionSmoothing([t]);
+    expect(controlStep(t, [1, 1])).toEqual([0.5, 0.5]);
+  });
+
+  it('smooths the clamped target, so a clip bounds the filter too', () => {
+    const t = term({
+      emaAlpha: 1,
+      clipHi: Float32Array.from([0.25, 0.25]),
+      defaultJointPos: new Float32Array(2),
+    });
+    expect(controlStep(t, [1, 1])).toEqual([0.25, 0.25]);
   });
 });

--- a/src/mjswan/template/src/core/action/applyAction.ts
+++ b/src/mjswan/template/src/core/action/applyAction.ts
@@ -51,6 +51,80 @@ export interface ResolvedActionTerm {
    */
   clipLo: Float32Array;
   clipHi: Float32Array;
+  /**
+   * `joint_position*` only: EMA factor on the processed target, `1` for none. Applied
+   * by `advanceActionSmoothing`, so the filter advances with mjlab's `process_actions`
+   * rather than with the substeps `applyAction` runs over.
+   */
+  emaAlpha: number;
+  /** Control steps from episode start that hold the default pose; `0` for none. */
+  warmupSteps: number;
+  /** Smoothing state, `null` while neither `emaAlpha` nor `warmupSteps` is in play. */
+  smoothedTarget?: Float32Array | null;
+  /** Warmup steps left in this episode. */
+  warmupRemaining?: number;
+}
+
+/** `raw * scale + offset` off this term's base pose, clamped — mjlab's processed action. */
+function processedTarget(
+  term: ResolvedActionTerm,
+  i: number,
+  actions: Float32Array,
+): number {
+  const reference = term.referenceJointPos ?? null;
+  const index = term.actionIndices[i];
+  const base = reference ? (reference[index] ?? 0) : term.defaultJointPos[i];
+  return clamp(
+    base + term.actionOffset[i] + term.actionScale[i] * (actions[index] ?? 0),
+    term.clipLo[i],
+    term.clipHi[i],
+  );
+}
+
+/** Whether a term filters its target at all — the common case does not. */
+function isSmoothed(term: ResolvedActionTerm): boolean {
+  return term.emaAlpha < 1 || term.warmupSteps > 0;
+}
+
+/**
+ * Advance every smoothed term's target by one control step.
+ *
+ * Call once per control step, before the `decimation` substeps: the EMA is a recursion
+ * over control steps, so running it inside `applyAction` would advance it `decimation`
+ * times and shrink the effective time constant.
+ */
+export function advanceActionSmoothing(
+  terms: readonly ResolvedActionTerm[],
+  actions: Float32Array,
+): void {
+  for (const term of terms) {
+    if (!isSmoothed(term)) continue;
+    const n = term.ctrlAdr.length;
+    let smoothed = term.smoothedTarget;
+    if (!smoothed || smoothed.length !== n) {
+      smoothed = Float32Array.from(term.defaultJointPos);
+      term.smoothedTarget = smoothed;
+    }
+    const warmup = (term.warmupRemaining ?? term.warmupSteps) > 0;
+    const alpha = term.emaAlpha;
+    for (let i = 0; i < n; i++) {
+      smoothed[i] = warmup
+        ? term.defaultJointPos[i]
+        : alpha * processedTarget(term, i, actions) + (1 - alpha) * smoothed[i];
+    }
+    if (warmup) {
+      term.warmupRemaining = (term.warmupRemaining ?? term.warmupSteps) - 1;
+    }
+  }
+}
+
+/** Return every smoothed term to the default pose, as mjlab's `ActionTerm.reset` does. */
+export function resetActionSmoothing(terms: readonly ResolvedActionTerm[]): void {
+  for (const term of terms) {
+    if (!isSmoothed(term)) continue;
+    term.smoothedTarget = Float32Array.from(term.defaultJointPos);
+    term.warmupRemaining = term.warmupSteps;
+  }
 }
 
 /**
@@ -82,7 +156,6 @@ function applyActionTerm(
     actionIndices,
     actionScale,
     actionOffset,
-    defaultJointPos,
     encoderBias,
     positionActuator,
     kp,
@@ -93,18 +166,13 @@ function applyActionTerm(
   const ctrl = mjData.ctrl;
 
   if (controlType === 'joint_position' || controlType === 'joint_position_reference') {
-    const reference = term.referenceJointPos ?? null;
+    // Already advanced for this control step, so the substeps re-read one value.
+    const smoothed = isSmoothed(term) ? term.smoothedTarget : null;
     for (let i = 0; i < numJoints; i++) {
       const ctrlIndex = ctrlAdr[i];
       if (ctrlIndex < 0) continue;
-      const actionValue = actions[actionIndices[i]] ?? 0;
-      const base = reference ? (reference[actionIndices[i]] ?? 0) : defaultJointPos[i];
+      const processed = smoothed ? smoothed[i] : processedTarget(term, i, actions);
       // Un-bias the target: the policy was trained against a biased reading.
-      const processed = clamp(
-        base + actionOffset[i] + actionScale[i] * actionValue,
-        term.clipLo[i],
-        term.clipHi[i],
-      );
       const target = processed - encoderBias[i];
 
       if (positionActuator[i]) {

--- a/src/mjswan/template/src/core/engine/runtime.ts
+++ b/src/mjswan/template/src/core/engine/runtime.ts
@@ -30,8 +30,10 @@ import {
   updateCameraFromData,
 } from './viewer_config';
 import {
+  advanceActionSmoothing,
   clampActions,
   readClipActions,
+  resetActionSmoothing,
   resolveActionClip,
   stepPhysics,
   type ResolvedActionTerm,
@@ -1060,7 +1062,9 @@ export class mjswanRuntime {
       configStiffness: number[] | number | Record<string, number> | undefined,
       configDamping: number[] | number | Record<string, number> | undefined,
       useDefaultOffset: boolean,
-      configClip?: Record<string, readonly number[]>
+      configClip?: Record<string, readonly number[]>,
+      configEmaAlpha?: number,
+      configWarmupTimeS?: number
     ) => {
       const n = mapping.qposAdr.length;
       const subsetJointNames = mapping.actionIndices.map((i) => jointNames[i]);
@@ -1128,6 +1132,11 @@ export class mjswanRuntime {
         muscleNormalize: false,
         clipLo,
         clipHi,
+        emaAlpha: configEmaAlpha ?? 1,
+        // Whole control steps, as mjlab's `episode_length_buf * step_dt < warmup_time_s`.
+        warmupSteps: configWarmupTimeS
+          ? Math.ceil(configWarmupTimeS / (this.controlDt ?? DEFAULT_VIEWER_CONTROL_DT))
+          : 0,
       };
     };
 
@@ -1212,6 +1221,8 @@ export class mjswanRuntime {
           kp: new Float32Array(n),
           kd: new Float32Array(n),
           muscleNormalize,
+          emaAlpha: 1,
+          warmupSteps: 0,
           ...resolveActionClip(
             actionTerm.clip as Record<string, readonly number[]> | undefined,
             muscleMapping.ctrlAdr.map((_, i) => patterns[i] ?? ''),
@@ -1257,7 +1268,9 @@ export class mjswanRuntime {
         actionTerm.stiffness as number[] | number | Record<string, number> | undefined,
         actionTerm.damping as number[] | number | Record<string, number> | undefined,
         useDefaultOffset,
-        actionTerm.clip as Record<string, readonly number[]> | undefined
+        actionTerm.clip as Record<string, readonly number[]> | undefined,
+        actionTerm.ema_alpha as number | undefined,
+        actionTerm.warmup_time_s as number | undefined
       );
       if (controlType === 'joint_position_reference') {
         this.referenceActionCommands.set(entry, String(actionTerm.command_name ?? 'motion'));
@@ -1344,6 +1357,7 @@ export class mjswanRuntime {
     }
     this.onnxTimeStep = 0;
     this.lastSimState.bodies.clear();
+    resetActionSmoothing(this.policyControl ?? []);
 
     await applyResetTerms({
       events: this.eventManager,
@@ -1370,6 +1384,10 @@ export class mjswanRuntime {
     this.handMocap?.update(this.mjData);
 
     this.refreshActionReferences();
+    advanceActionSmoothing(
+      this.policyControl ?? [],
+      this.policyRunner?.getLastActions() ?? EMPTY_ACTIONS,
+    );
     stepPhysics(
       this.mujoco,
       this.mjModel,

--- a/src/mjswan/template/src/core/observation/FusedObservation.ts
+++ b/src/mjswan/template/src/core/observation/FusedObservation.ts
@@ -33,6 +33,8 @@ export interface FusedNativeInput {
   action_name?: string;
   /** `prev_action` with an `action_name`: where that term's slice starts. */
   action_offset?: number;
+  /** `prev_action` only: control steps back, 0 (the default) being the newest. */
+  age?: number;
 }
 
 export interface FusedObservationConfig extends ObservationConfig {
@@ -111,7 +113,7 @@ export class FusedObservation extends ObservationBase<FusedObservationConfig> {
   private readNative(native: FusedNativeInput): Float32Array {
     const raw =
       native.native === 'prev_action'
-        ? sliceStoredActions(this.runner.getLastActions(), native)
+        ? sliceStoredActions(this.runner.getActions(native.age ?? 0), native)
         : this.readCommand(native);
     // `raw` may be the runtime's own buffer, and the graph declared a fixed width.
     return conformToSize(Float32Array.from(raw), native.size);

--- a/src/mjswan/template/src/core/observation/NativeObservation.ts
+++ b/src/mjswan/template/src/core/observation/NativeObservation.ts
@@ -2,7 +2,8 @@
  * Observation terms that are a plain read of state the orchestrator already owns, so
  * tracing them would only wrap an identity graph around a value in hand. The build
  * marks them `native`:
- * - `prev_action` — mjlab's `last_action`.
+ * - `prev_action` — mjlab's `last_action`, or an older entry of its action window
+ *   when `age` is set (mjlab's `prev_action` / `prev_prev_action`).
  * - `command` — mjlab's `generated_commands`, the named term's current value.
  * - `constant` — reads nothing from the env; its value is baked at build time.
  *
@@ -33,6 +34,8 @@ export interface NativeObservationConfig extends ObservationConfig {
   action_name?: string;
   /** `prev_action` with an `action_name`: where that term's slice starts. */
   action_offset?: number;
+  /** `prev_action` only: control steps back, 0 (the default) being the newest. */
+  age?: number;
   scale?: ObservationScale;
   clip?: ObservationClip;
 }
@@ -124,7 +127,10 @@ export class NativeObservation extends ObservationBase<NativeObservationConfig> 
       case 'constant':
         return this.constant ?? new Float32Array(0);
       case 'prev_action':
-        return sliceStoredActions(this.runner.getLastActions(), this.config);
+        return sliceStoredActions(
+          this.runner.getActions(this.config.age ?? 0),
+          this.config,
+        );
       case 'command': {
         const name = this.config.command_name;
         const manager = this.runner.getContext()?.commandManager;

--- a/src/mjswan/template/src/core/observation/__tests__/FusedObservation.test.ts
+++ b/src/mjswan/template/src/core/observation/__tests__/FusedObservation.test.ts
@@ -63,6 +63,7 @@ const CFG: FusedObservationConfig = {
 function fakeRunner(): PolicyRunner {
   return {
     getLastActions: () => new Float32Array([0.5, -0.5]),
+    getActions: () => new Float32Array([0.5, -0.5]),
     getContext: () => ({
       commandManager: {
         getCommand: () => new Float32Array([1, 2, 3]),
@@ -105,6 +106,7 @@ describe('FusedObservation', () => {
     const session = new FakeSession(() => new Float32Array(6));
     const runner = {
       getLastActions: () => new Float32Array([1, 2, 3, 4]), // 4, graph wants 2
+      getActions: () => new Float32Array([1, 2, 3, 4]),
       getContext: () => null,
     } as unknown as PolicyRunner;
     const term = new FusedObservation(runner, CFG, {
@@ -142,6 +144,7 @@ describe('FusedObservation', () => {
     const session = new FakeSession(() => new Float32Array(6));
     const runner = {
       getLastActions: () => Float32Array.from([1, 2, 3, 9]),
+      getActions: () => Float32Array.from([1, 2, 3, 9]),
       getContext: () => null,
     } as unknown as PolicyRunner;
     const config: FusedObservationConfig = {

--- a/src/mjswan/template/src/core/observation/__tests__/OnnxObservation.test.ts
+++ b/src/mjswan/template/src/core/observation/__tests__/OnnxObservation.test.ts
@@ -41,10 +41,13 @@ class FakeSession implements OnnxSession {
  */
 function fakeRunner(overrides: Partial<{
   lastActions: Float32Array;
+  olderActions: Float32Array[];
   commands: Record<string, Float32Array>;
 }> = {}): PolicyRunner {
+  const window = [overrides.lastActions ?? new Float32Array(0), ...(overrides.olderActions ?? [])];
   return {
-    getLastActions: () => overrides.lastActions ?? new Float32Array(0),
+    getLastActions: () => window[0],
+    getActions: (age: number) => window[age] ?? new Float32Array(window[0].length),
     getContext: () => ({
       commandManager: {
         getCommand: (name: string) =>
@@ -277,5 +280,50 @@ describe('observation pipeline helpers', () => {
   it('is a no-op without scale or clip', () => {
     const values = Float32Array.from([1, -5, 3]);
     expect(Array.from(applyObservationPipeline(values, {}))).toEqual([1, -5, 3]);
+  });
+});
+
+/**
+ * `age` reaches back into mjlab's action window (`prev_action`, `prev_prev_action`),
+ * which a task observing action history reads instead of the newest entry.
+ */
+describe('NativeObservation — prev_action age', () => {
+  const window = {
+    lastActions: Float32Array.from([1, 2]),
+    olderActions: [Float32Array.from([3, 4]), Float32Array.from([5, 6])],
+  };
+
+  it('defaults to the newest action, as last_action does', () => {
+    const term = new NativeObservation(fakeRunner(window), {
+      name: 'a',
+      native: 'prev_action',
+      size: 2,
+    });
+    expect(Array.from(term.compute({} as never))).toEqual([1, 2]);
+  });
+
+  it('reads one and two steps back', () => {
+    for (const [age, expected] of [
+      [1, [3, 4]],
+      [2, [5, 6]],
+    ] as const) {
+      const term = new NativeObservation(fakeRunner(window), {
+        name: 'a',
+        native: 'prev_action',
+        size: 2,
+        age,
+      });
+      expect(Array.from(term.compute({} as never))).toEqual([...expected]);
+    }
+  });
+
+  it('reads zeros past the window, as mjlab does before that many steps', () => {
+    const term = new NativeObservation(fakeRunner(window), {
+      name: 'a',
+      native: 'prev_action',
+      size: 2,
+      age: 3,
+    });
+    expect(Array.from(term.compute({} as never))).toEqual([0, 0]);
   });
 });

--- a/src/mjswan/template/src/core/onnx/__tests__/slotReader.test.ts
+++ b/src/mjswan/template/src/core/onnx/__tests__/slotReader.test.ts
@@ -397,3 +397,76 @@ describe('createSlotReader — structured sensor fields', () => {
     close(read({ sensor: 'robot/imu_lin_vel' }), [1, 2, 3]);
   });
 });
+
+/**
+ * `joint_pos_target` is the one field that comes off `mjData.ctrl` rather than the
+ * state, so it is readable only where every one of the entity's joints is driven by a
+ * position actuator — the case in which mjlab's own `joint_pos_target` equals `ctrl`.
+ */
+describe('slotReader — joint_pos_target', () => {
+  function actuatedScene(biastype: number[]) {
+    const jointNames = ['arm/shoulder', 'arm/elbow'];
+    const encoder = new TextEncoder();
+    const all: number[] = [];
+    const adrOf = (names: string[]): number[] =>
+      names.map(name => {
+        const at = all.length;
+        all.push(...encoder.encode(name), 0);
+        return at;
+      });
+    const name_jntadr = adrOf(jointNames);
+    const name_bodyadr = adrOf(['world', 'arm/base']);
+    const mjModel = {
+      names: Uint8Array.from(all).buffer,
+      njnt: 2,
+      nbody: 2,
+      nsite: 0,
+      nsensor: 0,
+      name_jntadr,
+      name_bodyadr,
+      name_siteadr: [],
+      name_sensoradr: [],
+      jnt_type: [3, 3],
+      jnt_qposadr: [0, 1],
+      jnt_dofadr: [0, 1],
+      nu: 2,
+      // Deliberately not the identity: elbow's actuator comes first.
+      actuator_trntype: [0, 0],
+      actuator_trnid: [1, 0, 0, 0],
+      actuator_biastype: biastype,
+    } as unknown as Mutable;
+    const ctrl = Float64Array.from([0.7, -0.2]);
+    const mjData = { qpos: new Float64Array(2), qvel: new Float64Array(2), ctrl } as unknown as Mutable;
+    return { mjModel, mjData } as unknown as SlotReaderContext;
+  }
+
+  it('reads each joint through its own position actuator', () => {
+    const read = createSlotReader(() => actuatedScene([1, 1]));
+    // shoulder is actuator 1 (ctrl -0.2), elbow is actuator 0 (ctrl 0.7).
+    close(read({ entity: 'arm', field: 'joint_pos_target' }), [-0.2, 0.7]);
+  });
+
+  it('is the biased target mjlab stores, not the unbiased one it was built from', () => {
+    // mjlab's `joint_pos_target` is `processed - encoder_bias`, which is what `ctrl`
+    // holds; adding the bias back here would report a target no actuator was given.
+    const read = createSlotReader(() => actuatedScene([1, 1]), {
+      jointBias: name => (name === 'elbow' ? 0.25 : 0),
+    });
+    close(read({ entity: 'arm', field: 'joint_pos_target' }), [-0.2, 0.7]);
+  });
+
+  it('is unreadable when a joint is driven by a motor, whose ctrl is a force', () => {
+    const read = createSlotReader(() => actuatedScene([1, 0]));
+    expect(read({ entity: 'arm', field: 'joint_pos_target' })).toBeNull();
+  });
+
+  it('is unreadable for an entity carrying a multi-dof joint', () => {
+    // The shared fixture's robot has a ball joint: one actuator cannot address its 4 qpos.
+    const readShared = createSlotReader(() => context());
+    expect(readShared({ entity: 'robot', field: 'joint_pos_target' })).toBeNull();
+  });
+
+  it('is advertised as a readable field', () => {
+    expect(isReadableEntityField('joint_pos_target')).toBe(true);
+  });
+});

--- a/src/mjswan/template/src/core/onnx/slotReader.ts
+++ b/src/mjswan/template/src/core/onnx/slotReader.ts
@@ -52,6 +52,13 @@ type EntityIndex = {
   qvelAdr: number[];
   /** Encoder bias per joint, aligned to `qposAdr`. */
   jointBias: Float32Array;
+  /**
+   * `mjData.ctrl` address of each joint's position actuator, aligned to `qposAdr`;
+   * `-1` where the joint has none, or has one that commands force rather than a
+   * target. `null` if that is true of any of them, which is what makes
+   * `joint_pos_target` unreadable for the entity as a whole.
+   */
+  posCtrlAdr: number[] | null;
   /** mjlab's `root_body_id`: the entity's first non-world body. */
   rootBodyId: number;
   /** Model site ids belonging to the entity, in spec order. */
@@ -62,6 +69,8 @@ type EntityIndex = {
 const QPOS_WIDTH = [7, 4, 1, 1];
 const DOF_WIDTH = [6, 3, 1, 1];
 const MJ_JNT_FREE = 0;
+const MJ_TRN_JOINT = 0;
+const MJ_BIAS_AFFINE = 1;
 
 function decodeNames(mjModel: MjModel, count: number, adr: ArrayLike<number>): string[] {
   const bytes = new Uint8Array(mjModel.names);
@@ -111,9 +120,11 @@ function buildEntityIndex(
   // One verdict for the whole model, not per element kind.
   const prefixed = [...jointNames, ...bodyNames, ...siteNames].some(n => n.includes('/'));
 
+  const positionCtrl = positionActuatorByJoint(mjModel);
   const qposAdr: number[] = [];
   const qvelAdr: number[] = [];
   const bias: number[] = [];
+  const posCtrl: number[] = [];
   for (const j of scopedIndices(jointNames, entity, prefixed)) {
     const type = mjModel.jnt_type[j];
     if (type === MJ_JNT_FREE) continue; // mjlab keeps the free joint separate
@@ -123,6 +134,8 @@ function buildEntityIndex(
     for (let k = 0; k < qWidth; k++) {
       qposAdr.push(mjModel.jnt_qposadr[j] + k);
       bias.push(jointBias);
+      // Only a 1-qpos joint maps to one `ctrl`; a ball's actuator would be replicated.
+      posCtrl.push(qWidth === 1 ? (positionCtrl.get(j) ?? -1) : -1);
     }
     for (let k = 0; k < vWidth; k++) qvelAdr.push(mjModel.jnt_dofadr[j] + k);
   }
@@ -134,9 +147,26 @@ function buildEntityIndex(
     qposAdr,
     qvelAdr,
     jointBias: Float32Array.from(bias),
+    posCtrlAdr: posCtrl.every(adr => adr >= 0) ? posCtrl : null,
     rootBodyId: bodyIds.length > 0 ? bodyIds[0] : -1,
     siteIds: scopedIndices(siteNames, entity, prefixed),
   };
+}
+
+/**
+ * Joint id -> `ctrl` address, for position actuators only (`biastype=affine`).
+ *
+ * A motor actuator's `ctrl` is a force, so it says nothing about where the joint was
+ * told to go; only the affine ones carry mjlab's `joint_pos_target` in `ctrl`.
+ */
+function positionActuatorByJoint(mjModel: MjModel): Map<number, number> {
+  const byJoint = new Map<number, number>();
+  for (let a = 0; a < mjModel.nu; a++) {
+    if (mjModel.actuator_trntype[a] !== MJ_TRN_JOINT) continue;
+    if (mjModel.actuator_biastype[a] !== MJ_BIAS_AFFINE) continue;
+    byJoint.set(mjModel.actuator_trnid[a * 2], a);
+  }
+  return byJoint;
 }
 
 function gather(source: ArrayLike<number>, addresses: readonly number[]): Float32Array {
@@ -221,6 +251,10 @@ const FIELD_READERS: Record<string, FieldReader> = {
     return out;
   },
   joint_vel: (index, mjData) => gather(mjData.qvel, index.qvelAdr),
+  // The last target the action layer wrote. mjlab stores `processed - encoder_bias`
+  // here and writes the same value to `ctrl`, so for a position actuator `ctrl` is it.
+  joint_pos_target: (index, mjData) =>
+    index.posCtrlAdr && gather(mjData.ctrl, index.posCtrlAdr),
 
   root_link_pos_w: rootField((root, mjData) => vec3At(mjData.xpos, root)),
   root_link_quat_w: rootField((root, mjData) => quatAt(mjData.xquat, root)),

--- a/src/mjswan/template/src/core/policy/PolicyRunner.ts
+++ b/src/mjswan/template/src/core/policy/PolicyRunner.ts
@@ -81,6 +81,12 @@ export class PolicyRunner {
   private encoderBias: Float32Array;
   private numActions: number;
   private lastActions: Float32Array;
+  /**
+   * Older entries of mjlab's action window, newest first: `[prev_action,
+   * prev_prev_action]`. `lastActions` is `action`, so together they are the three
+   * `ActionManager` keeps.
+   */
+  private olderActions: Float32Array[];
   private motionCache: Map<string, Promise<ArrayBuffer | null>> = new Map();
 
   constructor(config: PolicyConfig, options: PolicyRunnerOptions = {}) {
@@ -99,6 +105,10 @@ export class PolicyRunner {
     this.policyJointNames = (config.policy_joint_names ?? []).slice();
     this.numActions = (config.policy_num_actions as number | undefined) ?? this.policyJointNames.length;
     this.lastActions = new Float32Array(this.numActions);
+    this.olderActions = [
+      new Float32Array(this.numActions),
+      new Float32Array(this.numActions),
+    ];
     this.defaultJointPos = this.normalizeArray(
       config.default_joint_pos ?? [],
       this.numActions,
@@ -119,6 +129,7 @@ export class PolicyRunner {
 
   reset(state?: PolicyState): void {
     this.lastActions.fill(0.0);
+    for (const actions of this.olderActions) actions.fill(0.0);
     this.policyModule?.reset();
     for (const obsList of Object.values(this.obsGroups)) {
       for (const obs of obsList) {
@@ -248,6 +259,17 @@ export class PolicyRunner {
     return new Float32Array(this.lastActions);
   }
 
+  /**
+   * The action `age` control steps back — 0 being the newest, as mjlab's `last_action`
+   * reads it. Ages past the window return zeros, which is what mjlab's own buffers
+   * hold before that many steps have run.
+   */
+  getActions(age: number): Float32Array {
+    if (age <= 0) return this.getLastActions();
+    const older = this.olderActions[age - 1];
+    return new Float32Array(older ?? new Float32Array(this.numActions));
+  }
+
   getConfig(): PolicyConfig {
     return this.config;
   }
@@ -265,10 +287,18 @@ export class PolicyRunner {
   }
 
   setLastActions(actions: Float32Array): void {
+    // Shift the window before overwriting the newest, as mjlab's `process_action` does.
     if (actions.length !== this.lastActions.length) {
+      // A different action width is a different policy; its history starts empty.
       this.lastActions = new Float32Array(actions);
+      this.olderActions = [
+        new Float32Array(actions.length),
+        new Float32Array(actions.length),
+      ];
       return;
     }
+    this.olderActions[1].set(this.olderActions[0]);
+    this.olderActions[0].set(this.lastActions);
     this.lastActions.set(actions);
   }
 

--- a/src/mjswan/template/src/core/policy/types.ts
+++ b/src/mjswan/template/src/core/policy/types.ts
@@ -44,6 +44,8 @@ export type ActionConfigEntry = {
   use_default_offset?: boolean;
   stiffness?: number | number[] | Record<string, number>;
   damping?: number | number[] | Record<string, number>;
+  ema_alpha?: number;
+  warmup_time_s?: number;
   actuator_names?: string[];
   [key: string]: unknown;
 };

--- a/tests/test_action_history_observation.py
+++ b/tests/test_action_history_observation.py
@@ -1,0 +1,90 @@
+"""`action_history`: mjlab's older action buffers, served natively (ADR 0005 §Decision).
+
+Layer: L1 (pure Python — a stub action manager, no mjlab env build).
+
+mjlab's `ActionManager` keeps a three-deep window of raw policy actions — `action`,
+`prev_action`, `prev_prev_action` — but its own `last_action` observation only ever
+reads the newest. A task observing action history reads the older two directly, which
+left them with no browser counterpart at all: not traceable (the action manager is not
+scene state) and not native (only `last_action` was).
+
+`action_history(age=...)` is that read, and is classified native so the runtime serves
+it from the same window rather than tracing a graph for it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mjswan.compile.tracer import (  # noqa: E402
+    NATIVE_OBSERVATION_FUNCS,
+    native_observation_entry,
+)
+from mjswan.envs.mdp.observations import action_history  # noqa: E402
+
+
+class _StubActionManager:
+    def __init__(self, terms: dict[str, int], window: list[list[float]]) -> None:
+        self.active_terms = list(terms)
+        self.action_term_dim = list(terms.values())
+        self.action, self.prev_action, self.prev_prev_action = (
+            torch.tensor([row]) for row in window
+        )
+
+
+class _StubEnv:
+    def __init__(self, terms: dict[str, int], window: list[list[float]]) -> None:
+        self.action_manager = _StubActionManager(terms, window)
+
+
+WINDOW = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+
+
+@pytest.fixture
+def env() -> _StubEnv:
+    return _StubEnv({"joint_pos": 3}, WINDOW)
+
+
+class TestRead:
+    @pytest.mark.parametrize("age,expected", list(enumerate(WINDOW)))
+    def test_age_walks_back_through_the_window(self, env, age, expected):
+        assert action_history(env, age=age).tolist() == [expected]
+
+    def test_default_is_one_step_back(self, env):
+        """`age=0` is mjlab's own `last_action`; this function exists for the rest."""
+        assert action_history(env).tolist() == [WINDOW[1]]
+
+    def test_age_past_the_window_raises(self, env):
+        with pytest.raises(ValueError, match="age"):
+            action_history(env, age=3)
+
+    def test_action_name_narrows_to_that_terms_slice(self):
+        env = _StubEnv({"arm": 2, "gripper": 1}, WINDOW)
+        assert action_history(env, age=1, action_name="gripper").tolist() == [[6.0]]
+
+    def test_unknown_action_name_raises_and_names_the_available_ones(self, env):
+        with pytest.raises(ValueError, match="joint_pos"):
+            action_history(env, action_name="nope")
+
+
+class TestNativeClassification:
+    def test_classified_as_prev_action(self):
+        assert NATIVE_OBSERVATION_FUNCS[action_history.__name__] == "prev_action"
+
+    def test_entry_carries_the_age(self, env):
+        entry = native_observation_entry("hist", action_history, {"age": 2}, env)
+        assert entry == {"name": "hist", "native": "prev_action", "age": 2}
+
+    def test_age_zero_is_omitted_so_it_reads_as_last_action(self, env):
+        entry = native_observation_entry("hist", action_history, {"age": 0}, env)
+        assert "age" not in entry
+
+    def test_entry_carries_the_slice_offset_alongside_the_age(self):
+        env = _StubEnv({"arm": 2, "gripper": 1}, WINDOW)
+        entry = native_observation_entry(
+            "hist", action_history, {"age": 1, "action_name": "gripper"}, env
+        )
+        assert entry["age"] == 1
+        assert entry["action_offset"] == 2

--- a/tests/test_joint_position_smoothing.py
+++ b/tests/test_joint_position_smoothing.py
@@ -1,0 +1,78 @@
+"""Tests for ``JointPositionActionCfg``'s ``ema_alpha`` / ``warmup_time_s``.
+
+Both mirror mjlab action terms that smooth the processed joint-position target across
+control steps and hold the default pose for the first moments of an episode. The
+filter itself runs browser-side; what is checked here is that the config validates its
+inputs and reaches ``policy.json`` for the TS runtime to read.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from mjswan.builder import Builder
+from mjswan.envs.mdp.actions import JointPositionActionCfg
+from mjswan.utils import name2id
+
+
+class TestSerialization:
+    def test_defaults_omit_both_fields(self):
+        assert (
+            JointPositionActionCfg()
+            .to_dict()
+            .keys()
+            .isdisjoint({"ema_alpha", "warmup_time_s"})
+        )
+
+    def test_values_emitted(self):
+        entry = JointPositionActionCfg(ema_alpha=0.5, warmup_time_s=0.4).to_dict()
+        assert entry["ema_alpha"] == 0.5
+        assert entry["warmup_time_s"] == 0.4
+
+    def test_no_op_values_omitted(self):
+        entry = JointPositionActionCfg(ema_alpha=1.0, warmup_time_s=0.0).to_dict()
+        assert "ema_alpha" not in entry
+        assert "warmup_time_s" not in entry
+
+    @pytest.mark.parametrize("alpha", [0.0, -0.1, 1.5])
+    def test_alpha_outside_unit_interval_raises(self, alpha):
+        with pytest.raises(ValueError, match="ema_alpha"):
+            JointPositionActionCfg(ema_alpha=alpha).to_dict()
+
+    def test_negative_warmup_raises(self):
+        with pytest.raises(ValueError, match="warmup_time_s"):
+            JointPositionActionCfg(warmup_time_s=-1.0).to_dict()
+
+
+class TestBuilderRoundTrip:
+    @pytest.fixture(autouse=True)
+    def _no_frontend(self, monkeypatch):
+        monkeypatch.setattr("mjswan.builder.ClientBuilder", MagicMock())
+        monkeypatch.setattr("mjswan.builder.shutil.copytree", MagicMock())
+
+    def test_fields_reach_policy_json(self, tmp_path, minimal_model, minimal_onnx):
+        builder = Builder()
+        scene = builder.add_project(name="P").add_scene(
+            control_dt=0.05, name="S", model=minimal_model
+        )
+        scene.add_policy(
+            name="Policy",
+            policy=minimal_onnx,
+            actions={
+                "joint_pos": JointPositionActionCfg(ema_alpha=0.5, warmup_time_s=0.4)
+            },
+        )
+        builder._save_web(tmp_path / "out")
+
+        data = json.loads(
+            (
+                tmp_path / "out" / "main" / "assets" / name2id("S") / "policy.json"
+            ).read_text()
+        )
+        term = data["actions"]["joint_pos"]
+        assert term["type"] == "joint_position"
+        assert term["ema_alpha"] == 0.5
+        assert term["warmup_time_s"] == 0.4


### PR DESCRIPTION
Porting [`wuji-technology/wuji-mjlab`](https://github.com/wuji-technology/wuji-mjlab)'s `WujiHand_Reorient` hit three walls, all the same root cause: an mjlab action term carries state of its own, and the browser modelled none of it. Each piece below is defined in `mjlab`, not in the task repo, so each is generic; the task is only what surfaced them.

## 1. `ema_alpha` / `warmup_time_s` on `JointPositionActionCfg`

The task's action term is mjlab's `JointPositionAction` plus EMA smoothing on the processed target and a warmup hold at the default pose. The action layer is permanently native (ADR 0005 §7), so there is no author-side rewrite — without this the task cannot be ported at all.

The filter advances in `advanceActionSmoothing`, called once per control step beside `refreshActionReferences`, **not** inside `applyAction`: `stepPhysics` re-applies the action `decimation` times, and advancing an EMA there would shrink its time constant by that factor. `applyAction` stays a pure function of what it is handed, which is what lets the rollout-parity harness drive it in Node.

`resetActionSmoothing` returns the window to the default pose on episode reset, as mjlab's `ActionTerm.reset` does.

## 2. `Entity.data.joint_pos_target` as a readable slot

The task's `qpos_error` observation reads `action_manager.get_term("joint_pos").processed_action`. Observation graphs have no action manager, but mjlab writes that same value — `processed - encoder_bias` — to `Entity.data.joint_pos_target` *and* to `ctrl`, so for a position actuator `ctrl` is it.

The reader is deliberately narrow: it returns `null` unless **every** one of the entity's joints is a 1-qpos joint driven by an affine-bias actuator. A motor's `ctrl` is a force, and a ball joint's single actuator cannot address its four qpos — reporting either as a target would be a plausible wrong number rather than a build error.

`encoder_bias` joins `_STATIC_DATA_FIELDS`. It is randomizable in mjlab, but the browser's action layer already bakes one build-time vector for it, so baking is what keeps the two agreeing.

## 3. `action_history`, for mjlab's older action buffers

`ActionManager` keeps `action`, `prev_action` and `prev_prev_action`. mjlab's own `last_action` observation only ever returns the newest, so a task observing `prev_action` — as this one does — had no route: not traceable (the action manager is not scene state) and not native (only `last_action` was classified).

`mjswan.envs.mdp.observations.action_history(env, age=...)` is that read at any age, classified `prev_action` like `last_action`, with the `age` travelling into the config and `PolicyRunner` holding the window. `age=0` is `last_action` exactly.

## Tests

- `tests/test_joint_position_smoothing.py` — validation and `policy.json` round-trip for the two new fields.
- `tests/test_action_history_observation.py` — the read at each age, slice narrowing, and native classification, against a stub action manager.
- `applyAction.test.ts` — geometric approach, pass-through at `alpha=1`, exact warmup length, once-per-control-step (not per substep), reset, and that the clip bounds the filter.
- `slotReader.test.ts` — per-joint actuator resolution, the biased-vs-unbiased distinction, and both unreadable cases.
- `OnnxObservation.test.ts` — `age` 0/1/2 and past the window.

`make format` clean, `pyright`/`ty` and `eslint` unchanged from baseline, `uv run pytest -m "not slow"` 651 passed, `vitest` 453 passed.

## What this does not cover

- Smoothing is on `joint_position` only. The TS branch is shared with `joint_position_reference`, so it would work there, but no cfg field exposes it and nothing tests it.
- The action window is three deep, matching `ActionManager`; a deeper history would need a real ring buffer.
- `joint_pos_target` is unavailable for entities with motor actuators — that would need the runtime to publish the action layer's computed target rather than read `ctrl`.
- Unrelated but found on the way: a termination that traces to a constant falls back to `_native_termination_entry`, which gives it `time_out` semantics. The task's `cage_drop` reads a reward term's counter, so it silently became a second time-out at `episode_length_s`. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)