### PR TITLE
Send the headers the Cloud signed, and commit with a live token

### DIFF
--- a/src/mjswan/publish.py
+++ b/src/mjswan/publish.py
@@ -169,10 +169,8 @@ class HttpTransport:
     ) -> HttpResponse:
         """PUT to a presigned URL.
 
-        Both header values are signed into the URL by the Cloud
-        (``SignedHeaders = cache-control;content-type;host``), so they are passed in
-        rather than derived here: a value this side invents is a 403, not a
-        differently-cached object.
+        Both headers are in the URL's ``SignedHeaders``, so the caller passes the
+        values the Cloud returned; one invented here is a 403.
         """
         headers = {"Content-Type": content_type, "User-Agent": USER_AGENT}
         if cache_control is not None:
@@ -436,10 +434,8 @@ def publish_dist(
                 url = upload["url"]
                 _check_presigned_url(url, path)
                 notify(f"Uploading {path} ({f.size} bytes)…")
-                # The server's own header values, never this side's: it signs both
-                # into the URL and returns them for exactly this reason. The local
-                # `_content_type_for` is the advisory sent *with* the manifest, and
-                # disagrees for `.mjz` — using it here was half of #119.
+                # The server's signed values, not this side's: `_content_type_for`
+                # is only the advisory sent with the manifest and disagrees for `.mjz`.
                 put_resp = transport.put_bytes(
                     url,
                     f.source.read_bytes(),
@@ -455,12 +451,9 @@ def publish_dist(
             commit_resp = transport.post_json(
                 f"{base}/api/simulations/commit",
                 {"upload_id": upload_id},
-                # Re-resolved, not reused: uploading a real build takes minutes
-                # (37 MB took ten), and a token resolved before the first PUT can
-                # cross its expiry before the last one. Every byte then lands in R2
-                # and the commit 401s, which reads as "not logged in" after a
-                # ten-minute wait. Cheap when the token is still good — the resolver
-                # only refreshes near expiry (#119).
+                # Re-resolved, not reused: an upload runs for minutes and can cross
+                # the token's expiry, landing every byte in R2 before the commit 401s.
+                # Near-free, since the resolver only refreshes close to expiry.
                 resolve_token(token),
             )
             _raise_for_status(commit_resp, "commit")

--- a/src/mjswan/publish.py
+++ b/src/mjswan/publish.py
@@ -160,13 +160,24 @@ class HttpTransport:
         )
         return self._send(req)
 
-    def put_bytes(self, url: str, data: bytes, content_type: str) -> HttpResponse:
-        req = urllib.request.Request(
-            url,
-            data=data,
-            method="PUT",
-            headers={"Content-Type": content_type, "User-Agent": USER_AGENT},
-        )
+    def put_bytes(
+        self,
+        url: str,
+        data: bytes,
+        content_type: str,
+        cache_control: str | None = None,
+    ) -> HttpResponse:
+        """PUT to a presigned URL.
+
+        Both header values are signed into the URL by the Cloud
+        (``SignedHeaders = cache-control;content-type;host``), so they are passed in
+        rather than derived here: a value this side invents is a 403, not a
+        differently-cached object.
+        """
+        headers = {"Content-Type": content_type, "User-Agent": USER_AGENT}
+        if cache_control is not None:
+            headers["Cache-Control"] = cache_control
+        req = urllib.request.Request(url, data=data, method="PUT", headers=headers)
         return self._send(req)
 
     @staticmethod
@@ -413,19 +424,27 @@ def publish_dist(
             upload_id = session.get("upload_id")
             if not upload_id:
                 raise PublishError("upload-session response missing upload_id.")
-            uploads = {u["path"]: u["url"] for u in session.get("uploads", [])}
+            uploads = {u["path"]: u for u in session.get("uploads", [])}
 
             by_path = {f.upload_path: f for f in plan.files}
-            for path, url in uploads.items():
+            for path, upload in uploads.items():
                 f = by_path.get(path)
                 if f is None:
                     raise PublishError(
                         f"Server requested upload for unknown file: {path}", file=path
                     )
+                url = upload["url"]
                 _check_presigned_url(url, path)
                 notify(f"Uploading {path} ({f.size} bytes)…")
+                # The server's own header values, never this side's: it signs both
+                # into the URL and returns them for exactly this reason. The local
+                # `_content_type_for` is the advisory sent *with* the manifest, and
+                # disagrees for `.mjz` — using it here was half of #119.
                 put_resp = transport.put_bytes(
-                    url, f.source.read_bytes(), _content_type_for(path)
+                    url,
+                    f.source.read_bytes(),
+                    upload.get("contentType") or _content_type_for(path),
+                    upload.get("cacheControl"),
                 )
                 if put_resp.status not in (200, 201, 204):
                     raise PublishError(
@@ -436,7 +455,13 @@ def publish_dist(
             commit_resp = transport.post_json(
                 f"{base}/api/simulations/commit",
                 {"upload_id": upload_id},
-                resolved_token,
+                # Re-resolved, not reused: uploading a real build takes minutes
+                # (37 MB took ten), and a token resolved before the first PUT can
+                # cross its expiry before the last one. Every byte then lands in R2
+                # and the commit 401s, which reads as "not logged in" after a
+                # ten-minute wait. Cheap when the token is still good — the resolver
+                # only refreshes near expiry (#119).
+                resolve_token(token),
             )
             _raise_for_status(commit_resp, "commit")
             commit = _parse_json(commit_resp, "commit")

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -140,7 +140,7 @@ class _Transport:
             )
         return HttpResponse(200, json.dumps({"id": "sim_1"}).encode())
 
-    def put_bytes(self, url, data, content_type):
+    def put_bytes(self, url, data, content_type, cache_control=None):
         self.puts.append(url.removeprefix("https://r2.example.com/"))
         return HttpResponse(200, b"")
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -73,9 +73,8 @@ class FakeTransport(HttpTransport):
                 return HttpResponse(
                     self._session_status, json.dumps(self._session_error).encode()
                 )
-            # Shaped like the real `PresignedUpload`: the server returns the exact
-            # header values it signed, and `.mjz` is octet-stream server-side even
-            # though the advisory the client sent says application/zip (#119).
+            # Shaped like the real `PresignedUpload`: the exact header values the
+            # server signed, with `.mjz` octet-stream (the client's advisory says zip).
             uploads = [
                 {
                     "path": entry["path"],
@@ -378,12 +377,7 @@ class TestPublishDist:
         assert all(".html" not in u and ".css" not in u for u in put_urls)
 
     def test_put_sends_the_headers_the_server_signed(self, tmp_path: Path):
-        """Both are in `SignedHeaders`, so a value this side invents is a 403 (#119).
-
-        The bug this covers shipped because the fake returned neither field, so the
-        client could drop `Cache-Control` entirely and guess a `Content-Type` with
-        every test still green — while every real publish failed at the first file.
-        """
+        """Both are in `SignedHeaders`, so a value this side invents is a 403."""
         dist = _make_dist(tmp_path)
         transport = FakeTransport()
         publish_dist(dist, title="My Sim", token="tok", transport=transport)
@@ -399,18 +393,12 @@ class TestPublishDist:
             )
             assert content_type == expected, url
 
-        # Specifically the disagreement the local table would have reintroduced:
-        # `_content_type_for` calls a `.mjz` application/zip, the server does not.
+        # `_content_type_for` calls a `.mjz` application/zip; the server does not.
         mjz = [v for u, v in by_url.items() if u.endswith(".mjz")]
         assert mjz and all(ct == "application/octet-stream" for ct, _ in mjz)
 
     def test_commit_re_resolves_the_token(self, tmp_path: Path, monkeypatch):
-        """A long upload can outlive the token, and the commit is what pays (#119).
-
-        Uploading a real build takes minutes, so a token resolved before the first
-        PUT can be expired by the last. Reusing it puts every byte in R2 and then
-        fails the commit with `Unauthorized`.
-        """
+        """A long upload can outlive the token, and the commit is what pays."""
         dist = _make_dist(tmp_path)
         transport = FakeTransport()
         tokens = iter(["token-at-upload", "token-at-commit"])

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -56,6 +56,7 @@ class FakeTransport(HttpTransport):
     ) -> None:
         self.posts: list[tuple[str, dict, str]] = []
         self.puts: list[tuple[str, int, str]] = []
+        self.put_headers: list[tuple[str, str, str | None]] = []
         self._sim_id = sim_id
         self._upload_id = upload_id
         self._commit_id = commit_id
@@ -72,10 +73,19 @@ class FakeTransport(HttpTransport):
                 return HttpResponse(
                     self._session_status, json.dumps(self._session_error).encode()
                 )
+            # Shaped like the real `PresignedUpload`: the server returns the exact
+            # header values it signed, and `.mjz` is octet-stream server-side even
+            # though the advisory the client sent says application/zip (#119).
             uploads = [
                 {
                     "path": entry["path"],
                     "url": f"https://r2.example.com/{entry['path']}",
+                    "contentType": (
+                        "application/json"
+                        if entry["path"].endswith(".json")
+                        else "application/octet-stream"
+                    ),
+                    "cacheControl": "public, max-age=31536000, immutable",
                 }
                 for entry in body["manifest"]
             ]
@@ -95,8 +105,15 @@ class FakeTransport(HttpTransport):
             return HttpResponse(self._commit_status, json.dumps(body_out).encode())
         raise AssertionError(f"unexpected POST {url}")
 
-    def put_bytes(self, url: str, data: bytes, content_type: str) -> HttpResponse:
+    def put_bytes(
+        self,
+        url: str,
+        data: bytes,
+        content_type: str,
+        cache_control: str | None = None,
+    ) -> HttpResponse:
         self.puts.append((url, len(data), content_type))
+        self.put_headers.append((url, content_type, cache_control))
         return HttpResponse(self._put_status, b"")
 
 
@@ -359,6 +376,51 @@ class TestPublishDist:
         put_urls = {url for url, _, _ in transport.puts}
         assert "https://r2.example.com/manifest.json" in put_urls
         assert all(".html" not in u and ".css" not in u for u in put_urls)
+
+    def test_put_sends_the_headers_the_server_signed(self, tmp_path: Path):
+        """Both are in `SignedHeaders`, so a value this side invents is a 403 (#119).
+
+        The bug this covers shipped because the fake returned neither field, so the
+        client could drop `Cache-Control` entirely and guess a `Content-Type` with
+        every test still green — while every real publish failed at the first file.
+        """
+        dist = _make_dist(tmp_path)
+        transport = FakeTransport()
+        publish_dist(dist, title="My Sim", token="tok", transport=transport)
+
+        by_url = {url: (ct, cc) for url, ct, cc in transport.put_headers}
+        assert by_url  # the loop ran at all
+        for url, (content_type, cache_control) in by_url.items():
+            assert cache_control == "public, max-age=31536000, immutable", url
+            expected = (
+                "application/json"
+                if url.endswith(".json")
+                else "application/octet-stream"
+            )
+            assert content_type == expected, url
+
+        # Specifically the disagreement the local table would have reintroduced:
+        # `_content_type_for` calls a `.mjz` application/zip, the server does not.
+        mjz = [v for u, v in by_url.items() if u.endswith(".mjz")]
+        assert mjz and all(ct == "application/octet-stream" for ct, _ in mjz)
+
+    def test_commit_re_resolves_the_token(self, tmp_path: Path, monkeypatch):
+        """A long upload can outlive the token, and the commit is what pays (#119).
+
+        Uploading a real build takes minutes, so a token resolved before the first
+        PUT can be expired by the last. Reusing it puts every byte in R2 and then
+        fails the commit with `Unauthorized`.
+        """
+        dist = _make_dist(tmp_path)
+        transport = FakeTransport()
+        tokens = iter(["token-at-upload", "token-at-commit"])
+        monkeypatch.setattr("mjswan.publish.resolve_token", lambda _t: next(tokens))
+
+        publish_dist(dist, title="T", token="ignored", transport=transport)
+
+        used = {url.rsplit("/", 1)[-1]: tok for url, _, tok in transport.posts}
+        assert used["upload-session"] == "token-at-upload"
+        assert used["commit"] == "token-at-commit"
 
     def test_authorization_header_and_body(self, tmp_path: Path):
         dist = _make_dist(tmp_path)


### PR DESCRIPTION
Closes #119.

`mjswan publish` has been failing on every real run. Found while publishing a
37 MB build to the RC environment; two bugs, one behind the other.

## 1. The presigned PUT was refused

```
Requesting upload session for 31 file(s)…
Uploading manifest.json (86912 bytes)…
Publish failed: Upload failed for manifest.json: HTTP 403 (manifest.json)
```

Auth, the version gate and manifest validation all passed — the session was
granted. R2 rejected the `PUT`.

mjswan Cloud signs three headers into each presigned URL
(`SignedHeaders = cache-control;content-type;host`) and returns the exact values
to send on each `uploads` entry. Its own browser uploader sends both verbatim.
This client kept only the URL:

- **no `Cache-Control` at all**, though it is in the signature — that alone is the 403;
- **a locally guessed `Content-Type`**, from a table that calls a `.mjz`
  `application/zip` where the server signs `application/octet-stream`. A second,
  independent mismatch that would have surfaced the moment the first was fixed.

The server returns those fields precisely so that no client holds its own copy of
what the signature depends on. Now it uses them.

## 2. The commit outlived the token

With the headers fixed, all 31 files uploaded — and the commit answered
`Unauthorized`. The token was resolved once, before the first `PUT`. Uploading
took ten minutes, which is long enough to cross the token's expiry, so every byte
landed in R2 and the publish failed at the last step. To the user that reads as
"not logged in" after a ten-minute wait.

The commit now re-resolves. The resolver only refreshes near expiry, so this costs
nothing when the token is still good.

## Why the suite was green

Both fake transports returned neither header field and never varied the token, so
the client could drop `Cache-Control`, invent a `Content-Type` and reuse a stale
token with every test passing. They now model what the server actually sends, and
two tests pin the behaviour:

- `test_put_sends_the_headers_the_server_signed`
- `test_commit_re_resolves_the_token`

707 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)