### PR TITLE
Write each traced term's provenance into the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ velocity-command shortcuts were removed outright, see Removed.
 
 ### Added
 
+- **Every term entry says which function it is** ([#118](https://github.com/ttktjmt/mjswan/issues/118)):
+  `func` (`<module>:<qualname>`), `doc` (the docstring's first line) and `params`
+  (JSON-safe: a `SceneEntityCfg` becomes `{entity, joint_names?, …}`) on observation
+  terms, fused-group `layout` rows, terminations and their `lanes`, events, and a
+  command's reset graph; a traced command names its class. Every written `.onnx` also
+  carries `producer_name = "mjswan"`, a `doc_string` and `metadata_props`
+  `mjswan.kind` / `mjswan.term` / `mjswan.func`, so Netron's Model Properties name the
+  source. Additive — `format` stays 1 and the runtime ignores the keys; they exist for
+  readers of the document, mjswan Cloud's inspector first.
 - **The build output is a simulation document**
   ([ADR 0006](docs/adr/0006-swn-simulation-document.md)): one `manifest.json` at the
   root — `{format, version, uses_custom_js, plugins?, projects}`, every key `snake_case`

--- a/src/mjswan/_graph_io.py
+++ b/src/mjswan/_graph_io.py
@@ -22,9 +22,8 @@ def onnx_ref(kind: str, name: str, scope: str | None = None) -> str:
 def stamp_provenance(onnx_bytes: bytes, meta: dict[str, str]) -> bytes:
     """Write who traced a graph into the model itself.
 
-    A `.onnx` travels alone — into Netron, into mjswan Cloud's inspector — where the
-    manifest that names it is out of reach. `producer_name`, `doc_string` and
-    `metadata_props` (`mjswan.<key>`) are the fields every ONNX viewer already shows.
+    A `.onnx` travels without the manifest that names it, and these are the fields every
+    ONNX viewer shows.
     """
     import onnx
 
@@ -51,8 +50,7 @@ def write_onnx(
 
     A build wipes its output first, so an existing file is this build's: identical bytes
     are one term traced twice, different bytes mean two owners resolved to one path.
-    *meta* is stamped into the model first (:func:`stamp_provenance`), so that
-    comparison sees what lands on disk.
+    *meta* is stamped in first, so that comparison sees what lands on disk.
     """
     if meta:
         onnx_bytes = stamp_provenance(onnx_bytes, meta)

--- a/src/mjswan/_graph_io.py
+++ b/src/mjswan/_graph_io.py
@@ -19,12 +19,43 @@ def onnx_ref(kind: str, name: str, scope: str | None = None) -> str:
     return ref if scope is None else f"{scope}/{ref}"
 
 
-def write_onnx(out_dir: Path, ref: str, onnx_bytes: bytes) -> None:
+def stamp_provenance(onnx_bytes: bytes, meta: dict[str, str]) -> bytes:
+    """Write who traced a graph into the model itself.
+
+    A `.onnx` travels alone — into Netron, into mjswan Cloud's inspector — where the
+    manifest that names it is out of reach. `producer_name`, `doc_string` and
+    `metadata_props` (`mjswan.<key>`) are the fields every ONNX viewer already shows.
+    """
+    import onnx
+
+    from . import __version__
+
+    model = onnx.load_from_string(onnx_bytes)
+    model.producer_name = "mjswan"
+    model.producer_version = __version__
+    kind, term, func = meta.get("kind"), meta.get("term"), meta.get("func")
+    model.doc_string = f"mjswan {kind} graph {term!r}" + (
+        f", traced from {func}" if func else ""
+    )
+    del model.metadata_props[:]
+    for key, value in meta.items():
+        prop = model.metadata_props.add()
+        prop.key, prop.value = f"mjswan.{key}", value
+    return model.SerializeToString()
+
+
+def write_onnx(
+    out_dir: Path, ref: str, onnx_bytes: bytes, *, meta: dict[str, str] | None = None
+) -> None:
     """Write a traced graph, refusing to replace a different graph already at *ref*.
 
     A build wipes its output first, so an existing file is this build's: identical bytes
     are one term traced twice, different bytes mean two owners resolved to one path.
+    *meta* is stamped into the model first (:func:`stamp_provenance`), so that
+    comparison sees what lands on disk.
     """
+    if meta:
+        onnx_bytes = stamp_provenance(onnx_bytes, meta)
     path = out_dir / ref
     if path.is_file() and path.read_bytes() != onnx_bytes:
         raise ValueError(
@@ -36,4 +67,4 @@ def write_onnx(out_dir: Path, ref: str, onnx_bytes: bytes) -> None:
     path.write_bytes(onnx_bytes)
 
 
-__all__ = ["onnx_ref", "write_onnx"]
+__all__ = ["onnx_ref", "stamp_provenance", "write_onnx"]

--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -52,7 +52,7 @@ def _require_ts_src(kind: str, name: str, binding: Any) -> None:
     )
 
 
-# --- Provenance: what a term *is*, for whoever reads the document without the code ---
+# --- Provenance ---
 
 
 def _param_json(value: Any) -> Any:
@@ -63,8 +63,8 @@ def _param_json(value: Any) -> Any:
         isinstance(v, (bool, int, float, str)) for v in value
     ):
         return list(value)
-    # SceneEntityCfg (duck-typed): the entity and the name patterns it was declared
-    # with. Resolved ids are build-env indices and mean nothing to a reader.
+    # SceneEntityCfg, duck-typed. Its resolved ids are build-env indices and mean
+    # nothing to a reader, so only the declared name patterns travel.
     if isinstance(getattr(value, "name", None), str):
         out: dict[str, Any] = {"entity": value.name}
         for key in ("joint_names", "body_names", "geom_names", "site_names"):
@@ -78,11 +78,10 @@ def _param_json(value: Any) -> Any:
 
 
 def _provenance(func: Any, params: dict[str, Any] | None = None) -> dict[str, Any]:
-    """``func`` / ``doc`` / ``params`` for a term entry (mjswan issue #118).
+    """``func`` / ``doc`` / ``params`` for a term entry.
 
-    The manifest says what a term reads and how wide it is; this says which function
-    it is, which only the build knows. Additive, so the format stays where it is; the
-    runtime ignores every one of these keys.
+    The manifest says what a term reads and how wide it is; only the build knows which
+    function it is.
     """
     out: dict[str, Any] = {}
     module = getattr(func, "__module__", None)
@@ -1163,7 +1162,7 @@ def serialize_command(
             category=RuntimeWarning,
             stacklevel=3,
         )
-    # A traced command is a class, not a function; its provenance is that class.
+    # A traced command is a class, not a function.
     entry = write_command_artifact(
         export,
         out_dir,

--- a/src/mjswan/_onnx_build.py
+++ b/src/mjswan/_onnx_build.py
@@ -52,6 +52,60 @@ def _require_ts_src(kind: str, name: str, binding: Any) -> None:
     )
 
 
+# --- Provenance: what a term *is*, for whoever reads the document without the code ---
+
+
+def _param_json(value: Any) -> Any:
+    """A term param as a viewer can read it; never the object itself."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)) and all(
+        isinstance(v, (bool, int, float, str)) for v in value
+    ):
+        return list(value)
+    # SceneEntityCfg (duck-typed): the entity and the name patterns it was declared
+    # with. Resolved ids are build-env indices and mean nothing to a reader.
+    if isinstance(getattr(value, "name", None), str):
+        out: dict[str, Any] = {"entity": value.name}
+        for key in ("joint_names", "body_names", "geom_names", "site_names"):
+            names = getattr(value, key, None)
+            if isinstance(names, str):
+                out[key] = names
+            elif isinstance(names, (list, tuple)) and names:
+                out[key] = [str(n) for n in names]
+        return out
+    return type(value).__name__
+
+
+def _provenance(func: Any, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """``func`` / ``doc`` / ``params`` for a term entry (mjswan issue #118).
+
+    The manifest says what a term reads and how wide it is; this says which function
+    it is, which only the build knows. Additive, so the format stays where it is; the
+    runtime ignores every one of these keys.
+    """
+    out: dict[str, Any] = {}
+    module = getattr(func, "__module__", None)
+    qualname = getattr(func, "__qualname__", None) or getattr(func, "__name__", None)
+    if module and qualname:
+        out["func"] = f"{module}:{qualname}"
+    doc = inspect.getdoc(func)
+    if doc:
+        out["doc"] = doc.strip().splitlines()[0][:200]
+    if params:
+        out["params"] = {str(k): _param_json(v) for k, v in params.items()}
+    return out
+
+
+def _graph_meta(kind: str, term: str, func: Any = None) -> dict[str, str]:
+    """The ``metadata_props`` a written graph carries; see ``_graph_io.stamp_provenance``."""
+    meta = {"kind": kind, "term": term}
+    path = _provenance(func).get("func") if func is not None else None
+    if path:
+        meta["func"] = path
+    return meta
+
+
 # --- Observations ---
 
 
@@ -167,8 +221,11 @@ def serialize_observation_term(
 
     params = _resolved_params(term_cfg.params, env)
 
+    provenance = _provenance(func, params)
+
     native_entry = _native_observation_entry(name, func, params, env)
     if native_entry is not None:
+        native_entry.update(provenance)
         return _apply_observation_pipeline(native_entry, term_cfg, group_history_length)
 
     try:
@@ -186,10 +243,11 @@ def serialize_observation_term(
             "native": "constant",
             "value": values,
             "size": len(values),
+            **provenance,
         }
         return _apply_observation_pipeline(entry, term_cfg, group_history_length)
     ref = _onnx_ref("obs", name, scope)
-    _write_onnx(out_dir, ref, export.onnx_bytes)
+    _write_onnx(out_dir, ref, export.onnx_bytes, meta=_graph_meta("obs", name, func))
 
     # The runtime cannot infer `size`: inference is async, the group layout is not.
     entry = {
@@ -197,6 +255,7 @@ def serialize_observation_term(
         "onnx": ref,
         "size": _tensor_width(export.reference_output),
         "input_slots": slots_json(export),
+        **provenance,
     }
     return _apply_observation_pipeline(entry, term_cfg, group_history_length)
 
@@ -301,13 +360,20 @@ def _fused_group_entry(
     ]
     export = trace_observation_group(specs, env, name=group_name)
     ref = _onnx_ref("obs", group_name, scope)
-    _write_onnx(out_dir, ref, export.onnx_bytes)
+    _write_onnx(out_dir, ref, export.onnx_bytes, meta=_graph_meta("obs", group_name))
+    by_name = {spec.name: spec for spec in specs}
     entry: dict[str, Any] = {
         "fused": ref,
         "input_slots": slots_json(export),
         "native_inputs": export.native_inputs,
         # Per-term widths in concat order, for the runtime's group layout.
-        "layout": export.layout,
+        "layout": [
+            {
+                **row,
+                **_provenance(by_name[row["name"]].func, by_name[row["name"]].params),
+            }
+            for row in export.layout
+        ],
         "size": _tensor_width(export.reference_output),
     }
     sensors = _structured_sensor_descriptors(
@@ -494,11 +560,12 @@ def serialize_termination(
         return _native_termination_entry(name, term_cfg, env)
 
     ref = _onnx_ref("term", name, scope)
-    _write_onnx(out_dir, ref, export.onnx_bytes)
+    _write_onnx(out_dir, ref, export.onnx_bytes, meta=_graph_meta("term", name, func))
     entry: dict[str, Any] = {
         "name": name,
         "onnx": ref,
         "input_slots": slots_json(export),
+        **_provenance(func, _resolved_params(term_cfg.params, env)),
     }
     sensors = _structured_sensor_descriptors(
         export, env, owner=f"Termination term {name!r}"
@@ -519,6 +586,7 @@ def _native_termination_entry(
         "name": name,
         "native": "elapsed_s >= episode_length_s",
         "episode_length_s": float(getattr(env, "max_episode_length_s", 0.0)),
+        **_provenance(term_cfg.func, term_cfg.params),
     }
     if term_cfg.time_out:
         entry["time_out"] = True
@@ -619,13 +687,18 @@ def _fused_termination_entry(
     ]
     export = trace_termination_group(specs, env, name=group_name)
     ref = _onnx_ref("term", group_name, scope)
-    _write_onnx(out_dir, ref, export.onnx_bytes)
+    _write_onnx(out_dir, ref, export.onnx_bytes, meta=_graph_meta("term", group_name))
+    by_name = {spec.name: spec for spec in specs}
     return {
         "fused": ref,
         "input_slots": slots_json(export),
         # Lane order is the graph's; `time_out` rides along for the manager's split.
         "lanes": [
-            {"name": name, "time_out": bool(terms[name].time_out)}
+            {
+                "name": name,
+                "time_out": bool(terms[name].time_out),
+                **_provenance(by_name[name].func, by_name[name].params),
+            }
             for name in export.lanes
         ],
     }
@@ -896,6 +969,7 @@ def serialize_event(
         return term_cfg.to_dict()
 
     resolved = _resolved_params(term_cfg.params, env)
+    provenance = _provenance(func, resolved)
     try:
         export = trace_event_term(
             func,
@@ -909,7 +983,7 @@ def serialize_event(
         # from the seeded PRNG at load.
         descriptor = model_field_dr_descriptor(term_cfg, env, resolved)
         if descriptor is not None:
-            return {"name": name, "mode": term_cfg.mode, **descriptor}
+            return {"name": name, "mode": term_cfg.mode, **descriptor, **provenance}
         nothing_to_write = _event_writes_nothing_reason(term_cfg, env, resolved)
         if nothing_to_write is not None:
             return {
@@ -917,6 +991,7 @@ def serialize_event(
                 "mode": term_cfg.mode,
                 "native": True,
                 "reason": nothing_to_write,
+                **provenance,
             }
         raise ValueError(
             f"Event term {name!r} could not be traced: {exc} Emitting it as a no-op "
@@ -927,7 +1002,7 @@ def serialize_event(
         ) from exc
 
     ref = _onnx_ref("event", name, scope)
-    _write_onnx(out_dir, ref, export.onnx_bytes)
+    _write_onnx(out_dir, ref, export.onnx_bytes, meta=_graph_meta("event", name, func))
     entry: dict[str, Any] = {
         "name": name,
         "mode": term_cfg.mode,
@@ -936,6 +1011,7 @@ def serialize_event(
         "rand_ranges": export.rand_ranges,
         "input_slots": slots_json(export),
         "write_targets": export.write_targets,
+        **provenance,
     }
     if term_cfg.mode == "interval":
         entry["interval_range_s"] = (
@@ -1028,7 +1104,12 @@ def _serialize_reset_graph(
         mode="reset",
     )
     ref = _onnx_ref("command", graph_name, scope)
-    _write_onnx(out_dir, ref, export.onnx_bytes)
+    _write_onnx(
+        out_dir,
+        ref,
+        export.onnx_bytes,
+        meta=_graph_meta("command", graph_name, pending.func),
+    )
     return {
         "name": graph_name,
         "mode": "reset",
@@ -1037,6 +1118,7 @@ def _serialize_reset_graph(
         "rand_ranges": export.rand_ranges,
         "input_slots": slots_json(export),
         "write_targets": export.write_targets,
+        **_provenance(pending.func, _resolved_params(pending.params, env)),
     }
 
 
@@ -1081,7 +1163,8 @@ def serialize_command(
             category=RuntimeWarning,
             stacklevel=3,
         )
-    return write_command_artifact(
+    # A traced command is a class, not a function; its provenance is that class.
+    entry = write_command_artifact(
         export,
         out_dir,
         scope=scope,
@@ -1089,7 +1172,9 @@ def serialize_command(
         debug_vis=debug_vis,
         ui=pending.ui or _record_command_gui(term, name),
         viz=pending.viz,
+        meta=_graph_meta("command", name, type(term)),
     )
+    return {**entry, **_provenance(type(term))}
 
 
 def _record_command_gui(term: Any, name: str) -> dict[str, Any] | None:

--- a/src/mjswan/compile/serialize.py
+++ b/src/mjswan/compile/serialize.py
@@ -90,13 +90,15 @@ def write_command_artifact(
     debug_vis: bool = False,
     ui: dict[str, Any] | None = None,
     viz: list[dict[str, Any]] | None = None,
+    meta: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Write ``<out_dir>/[<scope>/]command/<name>.onnx`` and return its config entry.
 
-    *scope* is the owning policy's id; see :func:`mjswan._graph_io.onnx_ref`.
+    *scope* is the owning policy's id; see :func:`mjswan._graph_io.onnx_ref`. *meta*
+    is stamped into the graph (:func:`mjswan._graph_io.stamp_provenance`).
     """
     ref = _onnx_ref("command", export.name, scope)
-    _write_onnx(Path(out_dir), ref, export.onnx_bytes)
+    _write_onnx(Path(out_dir), ref, export.onnx_bytes, meta=meta)
     return command_config(
         export,
         onnx_ref=ref,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1231,7 +1231,9 @@ class TestSaveWebPolicyJson:
         # with `scale` folded in rather than shipped.
         group = data["observations"]["policy"]
         assert group["fused"] == "mdp/policy/obs/policy.onnx"
-        assert group["layout"] == [{"name": "joint_pos", "size": 2}]
+        assert [(r["name"], r["size"]) for r in group["layout"]] == [("joint_pos", 2)]
+        # The row also names the function it traces (#118).
+        assert group["layout"][0]["func"] == f"{__name__}:_fake_joint_pos_rel"
         assert group["size"] == 2
         assert "scale" not in group
         assert (out / "p" / "s" / group["fused"]).exists()
@@ -1370,9 +1372,9 @@ class TestSaveWebPolicyJson:
         assert native["action_offset"] == 3
         assert native["size"] == 1
         # And the group still fuses around it: the native term is a graph *input*.
-        assert group["layout"] == [
-            {"name": "joint_pos", "size": 2},
-            {"name": "gripper_action", "size": 1},
+        assert [(r["name"], r["size"]) for r in group["layout"]] == [
+            ("joint_pos", 2),
+            ("gripper_action", 1),
         ]
 
     def test_last_action_naming_no_action_term_fails_the_build(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1232,7 +1232,6 @@ class TestSaveWebPolicyJson:
         group = data["observations"]["policy"]
         assert group["fused"] == "mdp/policy/obs/policy.onnx"
         assert [(r["name"], r["size"]) for r in group["layout"]] == [("joint_pos", 2)]
-        # The row also names the function it traces (#118).
         assert group["layout"][0]["func"] == f"{__name__}:_fake_joint_pos_rel"
         assert group["size"] == 2
         assert "scale" not in group

--- a/tests/test_onnx_command_config.py
+++ b/tests/test_onnx_command_config.py
@@ -639,11 +639,13 @@ def test_terminations_fuse_into_one_graph_with_one_lane_per_term(tmp_path):
     fused = entries[FUSED_TERMINATION_KEY]
     assert fused["fused"] == "term/terminations.onnx"
     assert (tmp_path / fused["fused"]).exists()
-    # One lane per term in graph output order, each flagged truncation or not.
-    assert fused["lanes"] == [
-        {"name": "too_low", "time_out": False},
-        {"name": "tipped", "time_out": False},
+    # One lane per term in graph output order, each flagged truncation or not, and
+    # naming the function it traces (#118).
+    assert [(lane["name"], lane["time_out"]) for lane in fused["lanes"]] == [
+        ("too_low", False),
+        ("tipped", False),
     ]
+    assert fused["lanes"][0]["func"] == f"{__name__}:_too_low"
     # Slots are the union of what the two terms read, deduplicated.
     assert sorted(s["field"] for s in fused["input_slots"]) == [
         "projected_gravity_b",

--- a/tests/test_onnx_command_config.py
+++ b/tests/test_onnx_command_config.py
@@ -639,8 +639,7 @@ def test_terminations_fuse_into_one_graph_with_one_lane_per_term(tmp_path):
     fused = entries[FUSED_TERMINATION_KEY]
     assert fused["fused"] == "term/terminations.onnx"
     assert (tmp_path / fused["fused"]).exists()
-    # One lane per term in graph output order, each flagged truncation or not, and
-    # naming the function it traces (#118).
+    # One lane per term in graph output order, each flagged truncation or not.
     assert [(lane["name"], lane["time_out"]) for lane in fused["lanes"]] == [
         ("too_low", False),
         ("tipped", False),

--- a/tests/test_term_provenance.py
+++ b/tests/test_term_provenance.py
@@ -1,0 +1,119 @@
+"""What a document says about *which function* a term is (issue #118).
+
+Layer: L1 (pure Python) for the manifest keys and the ONNX stamp, plus one
+torch-gated test through the real observation serializer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mjswan._graph_io import stamp_provenance, write_onnx
+from mjswan._onnx_build import _param_json, _provenance
+
+
+def base_lin_vel(env, asset_cfg):
+    """Root linear velocity in the asset's root frame.
+
+    Second paragraph, which must not travel.
+    """
+    del env, asset_cfg
+
+
+class _EntityCfg:
+    """Duck-typed SceneEntityCfg: a name plus the patterns it was declared with."""
+
+    def __init__(self):
+        self.name = "robot"
+        self.joint_names = [".*_hip_.*", ".*_knee_joint"]
+        self.body_names = None
+        self.joint_ids = [3, 4, 5]  # resolved indices: never serialized
+
+
+class TestProvenance:
+    def test_names_the_function_and_its_first_doc_line(self):
+        out = _provenance(base_lin_vel, {"asset_cfg": _EntityCfg()})
+        assert out["func"] == f"{__name__}:base_lin_vel"
+        assert out["doc"] == "Root linear velocity in the asset's root frame."
+        assert out["params"] == {
+            "asset_cfg": {
+                "entity": "robot",
+                "joint_names": [".*_hip_.*", ".*_knee_joint"],
+            }
+        }
+
+    def test_a_class_is_named_like_a_function(self):
+        out = _provenance(_EntityCfg)
+        assert out["func"] == f"{__name__}:_EntityCfg"
+        assert "params" not in out
+
+    def test_undocumented_lambda_still_gets_a_func(self):
+        out = _provenance(lambda env: env)
+        assert out["func"].endswith(".<lambda>")
+        assert "doc" not in out
+
+    def test_params_never_carry_objects(self):
+        assert _param_json(0.5) == 0.5
+        assert _param_json((1, 2)) == [1, 2]
+        assert _param_json(object()) == "object"
+        assert _param_json(None) is None
+
+
+def _tiny_model() -> bytes:
+    pytest.importorskip("onnx")
+    from onnx import TensorProto, helper
+
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3])
+    node = helper.make_node("Identity", ["x"], ["y"])
+    graph = helper.make_graph([node], "g", [x], [y])
+    return helper.make_model(graph).SerializeToString()
+
+
+class TestStamp:
+    def test_stamps_producer_doc_and_metadata(self):
+        onnx = pytest.importorskip("onnx")
+        stamped = stamp_provenance(
+            _tiny_model(), {"kind": "obs", "term": "actor", "func": "m:f"}
+        )
+        model = onnx.load_from_string(stamped)
+        assert model.producer_name == "mjswan"
+        assert model.doc_string == "mjswan obs graph 'actor', traced from m:f"
+        assert {p.key: p.value for p in model.metadata_props} == {
+            "mjswan.kind": "obs",
+            "mjswan.term": "actor",
+            "mjswan.func": "m:f",
+        }
+
+    def test_write_onnx_compares_what_lands_on_disk(self, tmp_path):
+        pytest.importorskip("onnx")
+        meta = {"kind": "obs", "term": "actor"}
+        write_onnx(tmp_path, "obs/actor.onnx", _tiny_model(), meta=meta)
+        # The same term traced twice, stamped twice, is still one graph.
+        write_onnx(tmp_path, "obs/actor.onnx", _tiny_model(), meta=meta)
+        with pytest.raises(ValueError, match="obs/actor.onnx"):
+            write_onnx(tmp_path, "obs/actor.onnx", _tiny_model(), meta={"kind": "term"})
+
+
+def test_constant_observation_entry_carries_provenance(tmp_path):
+    torch = pytest.importorskip("torch")
+    from mjswan._onnx_build import serialize_observation_term
+    from mjswan.managers.observation_manager import ObservationTermCfg
+
+    def padding(env, **_):
+        """A fixed-width padding term."""
+        del env
+        return torch.zeros(1, 5)
+
+    class _Env:
+        class scene:  # noqa: N801 — mirrors env.scene
+            sensors: dict = {}
+
+    entry = serialize_observation_term(
+        "pad", ObservationTermCfg(func=padding), _Env(), tmp_path, None
+    )
+    assert entry["native"] == "constant"
+    assert entry["func"].endswith(
+        ":test_constant_observation_entry_carries_provenance.<locals>.padding"
+    )
+    assert entry["doc"] == "A fixed-width padding term."

--- a/tests/test_term_provenance.py
+++ b/tests/test_term_provenance.py
@@ -1,4 +1,4 @@
-"""What a document says about *which function* a term is (issue #118).
+"""What a document says about *which function* a term is.
 
 Layer: L1 (pure Python) for the manifest keys and the ONNX stamp, plus one
 torch-gated test through the real observation serializer.


### PR DESCRIPTION
Closes #118.

## Why

mjswan Cloud is adding an Inspector to its watch page: an MDP wiring graph drawn
from `manifest.json` (slots → observation terms → fused group → policy → action,
plus terminations, commands and events), with each `.onnx` openable in Netron.

The manifest already says what a term *reads* and how wide it is — `input_slots`,
`size`, `layout`, `lanes`. It does not say what the term **is**. Only the build
knows that: the function object is in hand at trace time and gone afterwards, so
no consumer can recover it from the bytes.

## What

Every term entry the serializers emit gains:

- `func` — `"<module>:<qualname>"`, e.g. `mjlab.envs.mdp.observations:base_lin_vel`
- `doc` — the docstring's first line, when it has one
- `params` — JSON-safe. A `SceneEntityCfg` becomes its entity and the name patterns
  it was declared with, never its resolved ids: those are build-env indices and mean
  nothing to a reader.

Fused observation groups carry them per `layout` row, fused terminations per lane,
and a traced command names its class. Native and constant terms get them too.

Every graph `write_onnx` lands also gets `producer_name = "mjswan"`, a `doc_string`
and `metadata_props` (`mjswan.kind` / `mjswan.term` / `mjswan.func`), so a `.onnx`
opened on its own in Netron names its source in the Model Properties panel without
any Cloud-side work.

## Compatibility

Additive. `format` stays 1 — ADR 0006 §7 bumps it only for a break an older reader
would misread, and a reader that ignores unknown keys is unaffected. The runtime
ignores every one of these keys.

## Verified on a real build

`mjswan_playground`'s microduck task, 4 scenes and 9 policies:

```
row  {'name': 'joint_pos', 'size': 14, 'func': 'mjlab.envs.mdp.observations:joint_pos_rel'}
term {'name': 'fell_over', 'onnx': 'mdp/walk/term/fell_over.onnx',
      'func': 'mjlab.envs.mdp.terminations:bad_orientation',
      'doc': "Terminate when the asset's orientation exceeds the limit angle."}
```

New `tests/test_term_provenance.py`; three existing exact-equality assertions on
`layout` and `lanes` relaxed to accommodate the added keys. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)