### PR TITLE
Let a W&B policy declare its slot table

### DIFF
--- a/examples/mjlab/g1_spinkick/main.py
+++ b/examples/mjlab/g1_spinkick/main.py
@@ -47,9 +47,8 @@ def setup_builder() -> mjswan.Builder:
     # tracing env is built from the bundled copy at build time), and every term set via
     # the scene's env config.
     #
-    # `in_keys` is the exception, because nothing else can say it: this run's export
-    # takes two inputs, the observation group and mjlab's `time_step`, and the table is
-    # positional, so the network's own input names decide nothing (ADR 0006 §5).
+    # `in_keys` is the exception: the table is positional, so this run's two-input
+    # export cannot be read off the network's own input names (ADR 0006 §5).
     scene.add_policy_wandb(run_path, in_keys=["actor", "time_step"])
 
     return builder

--- a/examples/mjlab/g1_spinkick/main.py
+++ b/examples/mjlab/g1_spinkick/main.py
@@ -46,7 +46,11 @@ def setup_builder() -> mjswan.Builder:
     # The run supplies everything: the clip (mjlab registers `motion_file=""`, and the
     # tracing env is built from the bundled copy at build time), and every term set via
     # the scene's env config.
-    scene.add_policy_wandb(run_path)
+    #
+    # `in_keys` is the exception, because nothing else can say it: this run's export
+    # takes two inputs, the observation group and mjlab's `time_step`, and the table is
+    # positional, so the network's own input names decide nothing (ADR 0006 §5).
+    scene.add_policy_wandb(run_path, in_keys=["actor", "time_step"])
 
     return builder
 

--- a/src/mjswan/scene.py
+++ b/src/mjswan/scene.py
@@ -778,10 +778,9 @@ class SceneHandle:
             terminations: Termination term configurations applied to all fetched
                 policies.
             in_keys: ONNX input slot table applied to every fetched policy; see
-                :meth:`add_policy`. Every checkpoint of a run exports the same
-                network, so one table describes them all — and a run whose export
-                takes more than one input (an observation group plus a runtime
-                tensor such as ``time_step``) cannot be added without it.
+                :meth:`add_policy`. Required for a run whose export takes more than
+                one input (an observation group plus a runtime tensor such as
+                ``time_step``).
             out_keys: ONNX output slot table applied to every fetched policy; see
                 :meth:`add_policy`.
             clip_actions: Overrides the raw-action bound that would otherwise be

--- a/src/mjswan/scene.py
+++ b/src/mjswan/scene.py
@@ -738,6 +738,8 @@ class SceneHandle:
         commands: Mapping[str, Any] | None = None,
         actions: Mapping[str, ActionTermCfg] | Mapping[str, Any] | None = None,
         terminations: dict[str, TerminationTermCfg] | dict[str, Any] | None = None,
+        in_keys: Sequence[str] | None = None,
+        out_keys: Sequence[str | Sequence[str]] | None = None,
         clip_actions: float | None = None,
         extras: dict[str, Any] | None = None,
     ) -> list[PolicyHandle]:
@@ -775,6 +777,13 @@ class SceneHandle:
             actions: Action term configurations applied to all fetched policies.
             terminations: Termination term configurations applied to all fetched
                 policies.
+            in_keys: ONNX input slot table applied to every fetched policy; see
+                :meth:`add_policy`. Every checkpoint of a run exports the same
+                network, so one table describes them all — and a run whose export
+                takes more than one input (an observation group plus a runtime
+                tensor such as ``time_step``) cannot be added without it.
+            out_keys: ONNX output slot table applied to every fetched policy; see
+                :meth:`add_policy`.
             clip_actions: Overrides the raw-action bound that would otherwise be
                 read from the task's mjlab runner config. Only the
                 ``only_latest=True`` path needs it explicitly — that path skips
@@ -871,6 +880,8 @@ class SceneHandle:
                         env_cfg=env_cfg,
                         task_id=task_id,
                         mdp=shared_mdp,
+                        in_keys=in_keys,
+                        out_keys=out_keys,
                         clip_actions=clip_actions,
                         extras=extras,
                     )
@@ -964,6 +975,8 @@ class SceneHandle:
                                     default_joint_pos=export_context.default_joint_pos
                                     or None,
                                     encoder_bias=export_context.encoder_bias or None,
+                                    in_keys=in_keys,
+                                    out_keys=out_keys,
                                     clip_actions=clip_actions,
                                     extras=extras,
                                 )


### PR DESCRIPTION
A run whose checkpoints export more than one input could not be added through
`add_policy_wandb` at all:

```
ValueError: Policy 'model_0' has 2 ONNX inputs (['obs', 'time_step']) but
declares no in_keys. Pass in_keys naming, per input in order, the observation
group or runtime tensor (is_init, adapt_hx, time_step) that fills it.
```

The check is right. The table is positional, so the network's own input names
decide nothing (ADR 0006 §5), and nothing else records where the
runtime-synthesized tensors sit relative to the observation groups. But
`add_policy_wandb` accepted no `in_keys` / `out_keys`, so the only way to satisfy
it was `add_policy` — which means giving up the W&B path, and with it the
multi-checkpoint comparison that path exists for.

Every checkpoint of a run exports the same network, so one table describes them
all. It just needed forwarding, on both the `.pt` conversion path and the
`only_latest` one.

`examples/mjlab/g1_spinkick` is such a run and has been unbuildable. It now names
its two inputs, and builds: 7 checkpoints, each carrying the run's reference clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)